### PR TITLE
Api 8349 publish regression tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,3 +1,4 @@
+# For now any node image that used CentOS > 7 does not work with puppeteer. We will have to keep this image at Node12.
 FROM vasdvp/lighthouse-node-application-base:node12
 
 # Build Args

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM vasdvp/lighthouse-node-application-base:node16
+FROM vasdvp/lighthouse-node-application-base:node12
 
 # Build Args
 ARG BUILD_DATE_TIME

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,26 @@
 FROM vasdvp/lighthouse-node-application-base:node16
 
+# Build Args
+ARG BUILD_DATE_TIME
+ARG BUILD_VERSION
+ARG BUILD_NUMBER
+ARG BUILD_TOOL
+
+# Static Labels
+LABEL org.opencontainers.image.authors="Pivot!" \
+      org.opencontainers.image.url="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/blob/master/Dockerfile.test" \
+      org.opencontainers.image.documentation="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/blob/master/test/regression_tests/README.md" \
+      org.opencontainers.image.vendor="lighthouse" \
+      org.opencontainers.image.title="oauth-saml-tests" \
+      org.opencontainers.image.source="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy" \
+      org.opencontainers.image.description="SAML Proxy Tests for Lighthouse APIs"
+
+# Dynamic Labels
+LABEL org.opencontainers.image.created=${BUILD_DATE_TIME} \
+      org.opencontainers.image.version=${BUILD_VERSION} \
+      gov.va.build.number=${BUILD_NUMBER} \
+      gov.va.build.tool=${BUILD_TOOL}
+
 USER root
 
 WORKDIR /opt/va

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,7 +12,7 @@ LABEL org.opencontainers.image.authors="Pivot!" \
       org.opencontainers.image.url="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/blob/master/Dockerfile.test" \
       org.opencontainers.image.documentation="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/blob/master/test/regression_tests/README.md" \
       org.opencontainers.image.vendor="lighthouse" \
-      org.opencontainers.image.title="oauth-saml-tests" \
+      org.opencontainers.image.title="lighthouse-saml-tests" \
       org.opencontainers.image.source="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy" \
       org.opencontainers.image.description="SAML Proxy Tests for Lighthouse APIs"
 

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,13 @@ build/saml_tests : IMAGE = saml-proxy-tests
 build/saml_tests:
 	## build:	Build Docker image
 	docker build -t $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
-		-f $(patsubst %-tests,%,.)/Dockerfile.test \
+		-f Dockerfile.test \
 		--build-arg AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID) \
 		--build-arg BUILD_DATE_TIME=$(BUILD_DATE_TIME) \
 		--build-arg BUILD_TOOL=$(BUILD_TOOL) \
 		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
 		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
-		--no-cache $(patsubst %-tests,%,.)
+		--no-cache .
 
 ## lint: Linting
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -61,13 +61,13 @@ build/saml_tests : IMAGE = saml-proxy-tests
 build/saml_tests:
 	## build:	Build Docker image
 	docker build -t $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
-		-f $(patsubst %-tests,%,$(IMAGE))/Dockerfile.test \
+		-f $(patsubst %-tests,%,.)/Dockerfile.test \
 		--build-arg AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID) \
 		--build-arg BUILD_DATE_TIME=$(BUILD_DATE_TIME) \
 		--build-arg BUILD_TOOL=$(BUILD_TOOL) \
 		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
 		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
-		--no-cache $(patsubst %-tests,%,$(IMAGE))
+		--no-cache $(patsubst %-tests,%,.)
 
 ## lint: Linting
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,20 @@ build/saml:
 		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
 		--no-cache .
 
+## build/saml_tests:	Build saml-proxy image
+.PHONY: build/saml_tests
+build/saml_tests : IMAGE = saml-proxy-tests
+build/saml_tests:
+	## build:	Build Docker image
+	docker build -t $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
+		-f $(patsubst %-tests,%,$(IMAGE))/Dockerfile.test \
+		--build-arg AWS_ACCOUNT_ID=$(AWS_ACCOUNT_ID) \
+		--build-arg BUILD_DATE_TIME=$(BUILD_DATE_TIME) \
+		--build-arg BUILD_TOOL=$(BUILD_TOOL) \
+		--build-arg BUILD_VERSION=$(BUILD_VERSION) \
+		--build-arg BUILD_NUMBER=$(BUILD_NUMBER) \
+		--no-cache $(patsubst %-tests,%,$(IMAGE))
+
 ## lint: Linting
 .PHONY: lint
 lint:

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -55,6 +55,13 @@ phases:
          VERSION=${COMMIT_HASH} \
          BUILD_TOOL=CodeBuild \
          BUILD_NUMBER=${CODEBUILD_BUILD_ID}
+      - |
+        make build/saml_tests  \
+         TAG=${COMMIT_HASH} \
+         IMAGE=${IMAGE}-tests \
+         BUILD_VERSION=${COMMIT_HASH} \
+         BUILD_TOOL=CodeBuild \
+         BUILD_NUMBER=${CODEBUILD_BUILD_ID}
       # run linter
       - make lint IMAGE=${IMAGE} TAG=${COMMIT_HASH}
       # run unit tests
@@ -66,3 +73,5 @@ phases:
       - echo Pushing image to ECR
       - time="${time}\nPush - $(date +%r) - started"
       - make push IMAGE=${IMAGE} TAG=${COMMIT_HASH}
+      - echo Pushing tests image to ECR
+      - make push IMAGE=${IMAGE}-tests TAG=${COMMIT_HASH}


### PR DESCRIPTION
# Description

Publish Saml-Proxy-Tests image to ECR.

## Note

- The node16 upgrade also upgraded the test image. This broke the test-image build. I didn't catch that, but the way we currently use puppeteer only works with centos 7 and below. The Node 14 and 16 images are based in centos 8. I had to downgrade for this to work.