### PR TITLE
Api 8350 run saml proxy regression tests on deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,21 @@ test:
 		$(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
 		npm run test:ci
 
+## regression: Regression Tests
+.PHONY: regression
+regression:
+	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy-tests)
+	docker run \
+		-v "/var/run/docker.sock:/var/run/docker.sock" \
+		--rm $(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
+		--saml-proxy-url=$(SAML_PROXY_URL) \
+		--client-id=$(CLIENT_ID) \
+		--idp=$(IDP) \
+		--authorization-url=$(AUTHORIZATION_URL) \
+		--user-password=$(USER_PASSWORD) \
+		--valid-user=$(VALID_USER_EMAIL) \
+		--icn-error-user=$(ICN_ERROR_USER_EMAIL)
+
 ## pull: 	Pull an image to ECR
 .PHONY: pull
 pull:

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -42,7 +42,6 @@ env:
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
     SLACK_WEBHOOK: "/dvp/devops/codebuild_slack_webhook_lighthouse"
     # Values for regression tests
-    SAML_PROXY_URL: "/dvp/common/ecs-saml-proxy/codebuild/saml_proxy_url"
     CLIENT_ID: "/dvp/common/ecs-saml-proxy/codebuild/client_id"
     DEV_IDP: "/dvp/common/ecs-saml-proxy/codebuild/dev_idp"
     SANDBOX_IDP: "/dvp/common/ecs-saml-proxy/codebuild/sandbox_idp"

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -110,7 +110,7 @@ phases:
             make regression \
               TAG=${DEPLOY_TAG} \
               IMAGE=${IMAGE}-tests \
-              SAML_PROXY_URL=${SAML_PROXY_URL} \
+              SAML_PROXY_URL=https://${env}-api.va.gov \
               CLIENT_ID=${CLIENT_ID} \
               IDP=${IDP} \
               AUTHORIZATION_URL=${AUTHORIZATION_URL} \

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -51,6 +51,12 @@ env:
     VALID_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/valid_user_email"
     ICN_ERROR_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/icn_error_user_email"
 phases:
+  install:
+    commands:
+      # There is considerable slow down in the provisioning phase when using Amazon provided images.
+      # Therefore we use our own Alpine based image. In order to activate the Docker Daemon these lines are needed.
+      - /usr/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2 &
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   pre_build:
     commands:
       - printenv

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -45,7 +45,6 @@ env:
     CLIENT_ID: "/dvp/common/ecs-saml-proxy/codebuild/client_id"
     DEV_IDP: "/dvp/common/ecs-saml-proxy/codebuild/dev_idp"
     SANDBOX_IDP: "/dvp/common/ecs-saml-proxy/codebuild/sandbox_idp"
-    STAGING_IDP: "/dvp/common/ecs-saml-proxy/codebuild/staging_idp"
     AUTHORIZATION_URL: "/dvp/common/ecs-saml-proxy/codebuild/authorization_url"
     USER_PASSWORD: "/dvp/common/ecs-saml-proxy/codebuild/user_password"
     VALID_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/valid_user_email"

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -33,8 +33,19 @@ env:
     # Variables needed for ecs deployment
     AWS_APP_NAME: "ecs-saml-proxy"
   parameter-store:
+    # For pulling docker images
+    DOCKER_USERNAME: "/dvp/devops/DOCKER_USERNAME"
+    DOCKER_PASSWORD: "/dvp/devops/DOCKER_PASSWORD"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
     SLACK_WEBHOOK: "/dvp/devops/codebuild_slack_webhook_lighthouse"
+    # Values for regression tests
+    SAML_PROXY_URL: "/dvp/common/ecs-saml-proxy/codebuild/saml_proxy_url"
+    CLIENT_ID: "/dvp/common/ecs-saml-proxy/codebuild/client_id"
+    IDP: "/dvp/common/ecs-saml-proxy/codebuild/idp"
+    AUTHORIZATION_URL: "/dvp/common/ecs-saml-proxy/codebuild/authorization_url"
+    USER_PASSWORD: "/dvp/common/ecs-saml-proxy/codebuild/user_password"
+    VALID_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/valid_user_email"
+    ICN_ERROR_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/icn_error_user_email"
 phases:
   pre_build:
     commands:
@@ -78,6 +89,26 @@ phases:
             --tag ${DEPLOY_TAG} \
             --timeout 1200 || exit 1
             slackpost.sh -t success "Deployed SAML Proxy to ${env}."
+          if [[ ${env} != prod ]]; then
+            echo Logging into ECR
+            make login
+            echo Logging into Docker Hub
+            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+            echo Running regression tests.
+            make regression \
+              TAG=${DEPLOY_TAG} \
+              IMAGE=${IMAGE}-tests \
+              SAML_PROXY_URL=${SAML_PROXY_URL} \
+              CLIENT_ID=${CLIENT_ID} \
+              IDP=${IDP} \
+              AUTHORIZATION_URL=${AUTHORIZATION_URL} \
+              USER_PASSWORD=${USER_PASSWORD} \
+              VALID_USER_EMAIL=${VALID_USER_EMAIL} \
+              ICN_ERROR_USER_EMAIL=${ICN_ERROR_USER_EMAIL}
+            if [[ $? -gt 0 ]]; then
+              slackpost.sh -t warning "Some regression tests failed."
+            fi
+          fi
         done
   post_build:
     commands:

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -93,13 +93,11 @@ phases:
             --tag ${DEPLOY_TAG} \
             --timeout 1200 || exit 1
             slackpost.sh -t success "Deployed SAML Proxy to ${env}."
-          if [[ ${env} != prod ]]; then
+          if [[ ${env} != prod ]] && [[ ${env} != staging ]]; then
             if [[ ${env} = dev ]]; then
               IDP=${DEV_IDP}
             elif [[ ${env} = sandbox ]]; then
               IDP=${SANDBOX_IDP}
-            elif [[ ${env} = stagin ]]; then
-              IDP=${STAGING_IDP}
             fi
             echo Logging into ECR
             make login

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -44,7 +44,9 @@ env:
     # Values for regression tests
     SAML_PROXY_URL: "/dvp/common/ecs-saml-proxy/codebuild/saml_proxy_url"
     CLIENT_ID: "/dvp/common/ecs-saml-proxy/codebuild/client_id"
-    IDP: "/dvp/common/ecs-saml-proxy/codebuild/idp"
+    DEV_IDP: "/dvp/common/ecs-saml-proxy/codebuild/dev_idp"
+    SANDBOX_IDP: "/dvp/common/ecs-saml-proxy/codebuild/sandbox_idp"
+    STAGING_IDP: "/dvp/common/ecs-saml-proxy/codebuild/staging_idp"
     AUTHORIZATION_URL: "/dvp/common/ecs-saml-proxy/codebuild/authorization_url"
     USER_PASSWORD: "/dvp/common/ecs-saml-proxy/codebuild/user_password"
     VALID_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/valid_user_email"
@@ -93,6 +95,13 @@ phases:
             --timeout 1200 || exit 1
             slackpost.sh -t success "Deployed SAML Proxy to ${env}."
           if [[ ${env} != prod ]]; then
+            if [[ ${env} = dev ]]; then
+              IDP=${DEV_IDP}
+            elif [[ ${env} = sandbox ]]; then
+              IDP=${SANDBOX_IDP}
+            elif [[ ${env} = stagin ]]; then
+              IDP=${STAGING_IDP}
+            fi
             echo Logging into ECR
             make login
             echo Logging into Docker Hub

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -26,12 +26,15 @@ version: 0.2
 env:
   shell: bash
   variables:
+   # Honor Docker ignore at folder level
+    DOCKER_BUILDKIT: 1
     # These are the default deploy environments
     ENVIRONMENTS: "dev staging"
     # These are the deployable environments
     DEPLOYABLE_ENVIRONMENTS: "dev staging sandbox prod"
     # Variables needed for ecs deployment
     AWS_APP_NAME: "ecs-saml-proxy"
+    IMAGE: "saml-proxy"
   parameter-store:
     # For pulling docker images
     DOCKER_USERNAME: "/dvp/devops/DOCKER_USERNAME"

--- a/test/regression_tests/README.md
+++ b/test/regression_tests/README.md
@@ -9,7 +9,7 @@ export CLIENT_ID={ client id }
 export USER_PASSWORD={ user password }
 export AUTHORIZATION_URL={ ex. https://sandbox-api.va.gov/oauth2 }
 export VALID_USER_EMAIL={ ex. va.api.user+idme.001@gmail.com }
-export ICN_ERROR_USER_EMAIL={ ex. va.api.user+idme.043@gmail.com }
+export ICN_ERROR_USER_EMAIL={ ex. va.api.user+idme.049@gmail.com }
 export HEADLESS={ 0 (false) or 1 (true) } // note: this value only is important for local runs
 ```
 


### PR DESCRIPTION
Regression Tests will run on deploy in Dev and Sandbox. 

**Note**: Saml responses are encrypted in staging so some tests cannot run. I have decided to not test upon staging deploy, with some additional work I could probably get the tests that wont work on encrypted responses to be skipped in staging if that is preferable.

## Devops PR

https://github.com/department-of-veterans-affairs/devops/pull/9600

## Tests

Example of a test [failure](https://console.amazonaws-us-gov.com/codesuite/codebuild/008577686731/projects/saml-proxy-deploy/build/saml-proxy-deploy%3A7619a5dd-5149-4003-8a81-08eac22e1b00?region=us-gov-west-1).

Example of test [success](https://console.amazonaws-us-gov.com/codesuite/codebuild/008577686731/projects/saml-proxy-deploy/build/saml-proxy-deploy%3A54c415d8-8db8-402f-bbdf-90e0783cfbb5/?region=us-gov-west-1).