### PR TITLE
Updated test docker file to node16

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,3 @@
-# For now any node image that used CentOS > 7 does not work with puppeteer. We will have to keep this image at Node12.
 FROM vasdvp/lighthouse-node-application-base:node16
 
 # Build Args

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # For now any node image that used CentOS > 7 does not work with puppeteer. We will have to keep this image at Node12.
-FROM vasdvp/lighthouse-node-application-base:node12
+FROM vasdvp/lighthouse-node-application-base:node16
 
 # Build Args
 ARG BUILD_DATE_TIME
@@ -32,26 +32,10 @@ COPY --chown=node:node ./test/regression_tests/ .
 RUN npm i
 
 # Install chrome dependencies
-RUN yum install -y -q alsa-lib.x86_64 \
-                      atk.x86_64 \
-                      cups-libs.x86_64 \
-                      gtk3.x86_64 \
-                      ipa-gothic-fonts \
-                      libXcomposite.x86_64 \
-                      libXcursor.x86_64 \
-                      libXdamage.x86_64 \
-                      libXext.x86_64 \
-                      libXi.x86_64 \
-                      libXrandr.x86_64 \
-                      libXScrnSaver.x86_64 \
-                      libXtst.x86_64 \
-                      pango.x86_64 \
-                      xorg-x11-fonts-100dpi \
-                      xorg-x11-fonts-75dpi \
-                      xorg-x11-fonts-cyrillic \
-                      xorg-x11-fonts-misc \
-                      xorg-x11-fonts-Type1 \
-                      xorg-x11-utils
+# Install chrome dependencies
+RUN yum install -y -q wget
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+RUN dnf -y install google-chrome-stable_current_x86_64.rpm
 
 USER node
 


### PR DESCRIPTION
# Description

Part of API-8698. Upgrade all images that use puppeteer to Node16.

- Saml-Proxy-Regression tests <- this PR
  - https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/pull/341
- Lighthouse-Auth-Utils 
  - https://github.com/department-of-veterans-affairs/lighthouse-auth-utils/pull/23

Note: The oauth-proxy regression tests use bats to test, so it is not included in this PR.

## To Ensure Proper Functionality

Run Regression Test Docker Image

![image](https://user-images.githubusercontent.com/65039481/127199868-a4c47083-d904-4292-a948-0336732dae5c.png)
