### PR TITLE
API-10491 login gov sign up

### DIFF
--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -47,6 +47,7 @@ export default class SPConfig {
     this.failureFlash = true;
     this.category = argv.category || "id_me";
     this.signupLink = argv.spIdpSignupLink;
+    this.signupLinkEnabled = argv.spIdpSignupLinkEnabled;
   }
 
   getMetadataParams(req) {

--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -46,7 +46,6 @@ export default class SPConfig {
     this.failureRedirect = SP_ERROR_URL;
     this.failureFlash = true;
     this.category = argv.category || "id_me";
-    this.signupLink = argv.spIdpSignupLink;
     this.signupLinkEnabled = argv.spIdpSignupLinkEnabled;
   }
 

--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -46,6 +46,7 @@ export default class SPConfig {
     this.failureRedirect = SP_ERROR_URL;
     this.failureFlash = true;
     this.category = argv.category || "id_me";
+    this.signupLink = argv.spIdpSignupLink;
   }
 
   getMetadataParams(req) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -478,6 +478,11 @@ export function processArgs() {
           boolean: true,
           default: true,
         },
+        spIdpSignupLink: {
+          description: "Link to the Signup Page for the IDP",
+          required: false,
+          string: true,
+        },
       },
     })
     .example(

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -478,10 +478,11 @@ export function processArgs() {
           boolean: true,
           default: true,
         },
-        spIdpSignupLink: {
-          description: "Link to the Signup Page for the IDP",
+        spIdpSignupLinkEnabled: {
+          description: "Enables a link to the Signup Page for the IDP",
           required: false,
-          string: true,
+          boolean: true,
+          default: false,
         },
       },
     })

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -124,8 +124,10 @@ export const samlLogin = function (template) {
       }, Promise.resolve({}))
       .then((authOptions) => {
         authOptions.login_gov_enabled = login_gov_enabled;
-        authOptions.login_gov_signup_link_enabled =
-          req.sps.options.logingov.signupLinkEnabled;
+        if (login_gov_enabled) {
+          authOptions.login_gov_signup_link_enabled =
+            req.sps.options.logingov.signupLinkEnabled;
+        }
         res.render(template, authOptions);
         logger.info("User arrived from Okta. Rendering IDP login template.", {
           action: "parseSamlRequest",

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -84,12 +84,16 @@ export const samlLogin = function (template) {
         "login_gov_login_link",
         "http://idmanagement.gov/ns/assurance/ial/2",
       ]);
+      authnSelection.push([
+        "login_gov_signup_link",
+        "http://idmanagement.gov/ns/assurance/ial/2",
+      ]);
     }
 
     authnSelection
       .reduce((memo, [key, authnContext, exParams = null]) => {
         let idpKey = "id_me";
-        if (key === "login_gov_login_link") {
+        if (key === "login_gov_login_link" || key === "login_gov_signup_link") {
           idpKey = "logingov";
         }
         const params = req.sps.options[idpKey].getAuthnRequestParams(
@@ -118,13 +122,6 @@ export const samlLogin = function (template) {
       }, Promise.resolve({}))
       .then((authOptions) => {
         authOptions.login_gov_enabled = login_gov_enabled;
-        if (login_gov_enabled && req.sps.options.logingov.signupLink) {
-          authOptions.login_gov_signup_link =
-            req.sps.options.logingov.signupLink;
-          authOptions.login_gov_signup_link_enabled = true;
-        } else {
-          authOptions.login_gov_signup_link_enabled = false;
-        }
         res.render(template, authOptions);
         logger.info("User arrived from Okta. Rendering IDP login template.", {
           action: "parseSamlRequest",

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -84,10 +84,12 @@ export const samlLogin = function (template) {
         "login_gov_login_link",
         "http://idmanagement.gov/ns/assurance/ial/2",
       ]);
-      authnSelection.push([
-        "login_gov_signup_link",
-        "http://idmanagement.gov/ns/assurance/ial/2",
-      ]);
+      if (req.sps.options.logingov.signupLinkEnabled) {
+        authnSelection.push([
+          "login_gov_signup_link",
+          "http://idmanagement.gov/ns/assurance/ial/2",
+        ]);
+      }
     }
 
     authnSelection
@@ -122,6 +124,8 @@ export const samlLogin = function (template) {
       }, Promise.resolve({}))
       .then((authOptions) => {
         authOptions.login_gov_enabled = login_gov_enabled;
+        authOptions.login_gov_signup_link_enabled =
+          req.sps.options.logingov.signupLinkEnabled;
         res.render(template, authOptions);
         logger.info("User arrived from Okta. Rendering IDP login template.", {
           action: "parseSamlRequest",

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -118,6 +118,13 @@ export const samlLogin = function (template) {
       }, Promise.resolve({}))
       .then((authOptions) => {
         authOptions.login_gov_enabled = login_gov_enabled;
+        if (login_gov_enabled && req.sps.options.logingov.signupLink) {
+          authOptions.login_gov_signup_link =
+            req.sps.options.logingov.signupLink;
+          authOptions.login_gov_signup_link_enabled = true;
+        } else {
+          authOptions.login_gov_signup_link_enabled = false;
+        }
         res.render(template, authOptions);
         logger.info("User arrived from Okta. Rendering IDP login template.", {
           action: "parseSamlRequest",

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -124,10 +124,8 @@ export const samlLogin = function (template) {
       }, Promise.resolve({}))
       .then((authOptions) => {
         authOptions.login_gov_enabled = login_gov_enabled;
-        if (login_gov_enabled) {
-          authOptions.login_gov_signup_link_enabled =
-            req.sps.options.logingov.signupLinkEnabled;
-        }
+        authOptions.login_gov_signup_link_enabled =
+          login_gov_enabled && req.sps.options.logingov.signupLinkEnabled;
         res.render(template, authOptions);
         logger.info("User arrived from Okta. Rendering IDP login template.", {
           action: "parseSamlRequest",

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -211,7 +211,6 @@ describe("samlLogin", () => {
     id_me_signup_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=&op=signup",
     login_gov_enabled: false,
-    login_gov_signup_link_enabled: false,
   };
 
   const expected_authoptions_login_gov_enabled = {
@@ -226,8 +225,8 @@ describe("samlLogin", () => {
     login_gov_login_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
     login_gov_enabled: true,
-    login_gov_signup_link_enabled: true,
-    login_gov_signup_link: "http://example2.com/sign/me/up",
+    login_gov_signup_link:
+      "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
   };
 
   const mockGetSamlRequestUrl = jest

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -169,6 +169,7 @@ describe("samlLogin", () => {
           thumbprint: "thumbprint",
         };
       },
+      signupLink: "http://example2.com/sign/me/up",
       getAuthnRequestParams: () => {
         return {
           identityProviderUrl: "https://idp.int.identitysandbox.gov/api/saml",
@@ -210,6 +211,7 @@ describe("samlLogin", () => {
     id_me_signup_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=&op=signup",
     login_gov_enabled: false,
+    login_gov_signup_link_enabled: false,
   };
 
   const expected_authoptions_login_gov_enabled = {
@@ -224,6 +226,8 @@ describe("samlLogin", () => {
     login_gov_login_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
     login_gov_enabled: true,
+    login_gov_signup_link_enabled: true,
+    login_gov_signup_link: "http://example2.com/sign/me/up",
   };
 
   const mockGetSamlRequestUrl = jest

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -169,7 +169,7 @@ describe("samlLogin", () => {
           thumbprint: "thumbprint",
         };
       },
-      signupLink: "http://example2.com/sign/me/up",
+      signupLinkEnabled: true,
       getAuthnRequestParams: () => {
         return {
           identityProviderUrl: "https://idp.int.identitysandbox.gov/api/saml",
@@ -211,6 +211,7 @@ describe("samlLogin", () => {
     id_me_signup_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=&op=signup",
     login_gov_enabled: false,
+    login_gov_signup_link: false,
   };
 
   const expected_authoptions_login_gov_enabled = {
@@ -225,6 +226,7 @@ describe("samlLogin", () => {
     login_gov_login_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
     login_gov_enabled: true,
+    login_gov_signup_link_enabled: true,
     login_gov_signup_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
   };

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -211,7 +211,7 @@ describe("samlLogin", () => {
     id_me_signup_link:
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=&op=signup",
     login_gov_enabled: false,
-    login_gov_signup_link: false,
+    login_gov_signup_link_enabled: false,
   };
 
   const expected_authoptions_login_gov_enabled = {

--- a/views/login_selection.hbs
+++ b/views/login_selection.hbs
@@ -23,7 +23,7 @@
     <div class="usa-width-one-half">
       <h4>Don't have these accounts?</h4>
       <a class="no-external-icon usa-button idme-signup" href="{{ id_me_signup_link }}"><img alt="ID.me" src="/samlproxy/idp/img/idme-icon-dark.svg" />Create an ID.me account</a>
-      {{#if login_gov_signup_link_enabled}}
+      {{#if login_gov_enabled}}
       <a class="no-external-icon usa-button logingov-signup" href="{{ login_gov_signup_link }}"><img alt="Login.gov" src="/samlproxy/idp/img/icon-dot-gov.svg" />Create a Login.gov account</a>
       {{/if}}
       <p>Use your email, Google, or Facebook</p>

--- a/views/login_selection.hbs
+++ b/views/login_selection.hbs
@@ -24,7 +24,7 @@
       <h4>Don't have these accounts?</h4>
       <a class="no-external-icon usa-button idme-signup" href="{{ id_me_signup_link }}"><img alt="ID.me" src="/samlproxy/idp/img/idme-icon-dark.svg" />Create an ID.me account</a>
       {{#if login_gov_signup_link_enabled}}
-      <a class="no-external-icon usa-button logingov-signup" href="{{ login_gov_signup_link }}"><img alt="Login.gov" src="/samlproxy/idp/img/icon-dot-gov.svg" />Create an login.gov account</a>
+      <a class="no-external-icon usa-button logingov-signup" href="{{ login_gov_signup_link }}"><img alt="Login.gov" src="/samlproxy/idp/img/icon-dot-gov.svg" />Create a Login.gov account</a>
       {{/if}}
       <p>Use your email, Google, or Facebook</p>
     </div>

--- a/views/login_selection.hbs
+++ b/views/login_selection.hbs
@@ -23,7 +23,7 @@
     <div class="usa-width-one-half">
       <h4>Don't have these accounts?</h4>
       <a class="no-external-icon usa-button idme-signup" href="{{ id_me_signup_link }}"><img alt="ID.me" src="/samlproxy/idp/img/idme-icon-dark.svg" />Create an ID.me account</a>
-      {{#if login_gov_enabled}}
+      {{#if login_gov_signup_link_enabled}}
       <a class="no-external-icon usa-button logingov-signup" href="{{ login_gov_signup_link }}"><img alt="Login.gov" src="/samlproxy/idp/img/icon-dot-gov.svg" />Create a Login.gov account</a>
       {{/if}}
       <p>Use your email, Google, or Facebook</p>

--- a/views/login_selection.hbs
+++ b/views/login_selection.hbs
@@ -23,6 +23,9 @@
     <div class="usa-width-one-half">
       <h4>Don't have these accounts?</h4>
       <a class="no-external-icon usa-button idme-signup" href="{{ id_me_signup_link }}"><img alt="ID.me" src="/samlproxy/idp/img/idme-icon-dark.svg" />Create an ID.me account</a>
+      {{#if login_gov_signup_link_enabled}}
+      <a class="no-external-icon usa-button logingov-signup" href="{{ login_gov_signup_link }}"><img alt="Login.gov" src="/samlproxy/idp/img/icon-dot-gov.svg" />Create an login.gov account</a>
+      {{/if}}
       <p>Use your email, Google, or Facebook</p>
     </div>
   </div>


### PR DESCRIPTION
- Add a button on the saml-proxy UI for a user to register a login.gov account
  - This signup button can be enabled or disabled per environment
- In this case the signup page is the login page at login.gov. From there the user can press the "Create an account" button
![Screen Shot 2021-11-09 at 2 34 43 PM](https://user-images.githubusercontent.com/65245469/140992454-b32b9a16-46be-4d3c-99de-ae40cd86c545.png)

