### PR TITLE
API-11508 forced update to http-signature version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8945,12 +8945,10 @@
       }
     },
     "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": ">=1.3.6",
       "dependencies": {
         "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
+        "jsprim": "^2.0.2",
         "sshpk": "^1.7.0"
       },
       "engines": {
@@ -14056,12 +14054,10 @@
       }
     },
     "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "version": ">=1.3.6",
       "requires": {
         "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
+        "jsprim": "^2.0.2",
         "sshpk": "^1.7.0"
       }
     },
@@ -15065,8 +15061,7 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "requires": {
         "assert-plus": "1.0.0",
@@ -16295,7 +16290,7 @@
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
         "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
+        "http-signature": ">=1.3.6",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
@@ -16318,6 +16313,9 @@
             "combined-stream": "^1.0.6",
             "mime-types": "^2.1.12"
           }
+        },
+        "http-signature": {
+          "version": ">=1.3.6"
         },
         "qs": {
           "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   "resolutions": {
     "xml-crypto": ">=2.1.3",
     "trim-newlines": ">=3.0.1",
-    "normalize-url": "4.5.1"
+    "normalize-url": "4.5.1",
+    "http-signature": ">=1.3.6"
   }
 }


### PR DESCRIPTION
- Addresses a security update to json-schema via an upgrade to http-signature.
- Note, this was done via a forced resolution
- This is a short term fix
  - A longer term solution will be addressed by https://vajira.max.gov/browse/API-11511

- [x] Regression tests passed