### PR TITLE
API-11123 Login.gov Failure to Proof Support

### DIFF
--- a/src/routes/constants.ts
+++ b/src/routes/constants.ts
@@ -4,3 +4,4 @@ export const IDP_REDIRECT = "/samlproxy//idp/redirect";
 export const SP_METADATA_URL = "/samlproxy/sp/metadata";
 export const SP_ERROR_URL = "/samlproxy/sp/error";
 export const SP_VERIFY = "/samlproxy/sp/verify";
+export const SP_FAILURE_TO_PROOF = "/samlproxy/sp/failure-to-proof";

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -4,6 +4,7 @@ import {
   SP_METADATA_URL,
   SP_VERIFY,
   SP_ERROR_URL,
+  SP_FAILURE_TO_PROOF,
 } from "./constants";
 
 import {
@@ -49,6 +50,8 @@ export default function addRoutes(
   });
 
   app.get(SP_VERIFY, parseSamlRequest, samlLogin("verify"));
+
+  app.get(SP_FAILURE_TO_PROOF, parseSamlRequest, samlLogin("failureToProof"));
 
   acsFactory(app, acsUrl, cache, cacheEnabled);
 

--- a/views/failureToProof.hbs
+++ b/views/failureToProof.hbs
@@ -1,0 +1,15 @@
+<div class="usa-grid idme-signup-footer">
+  <div class="usa">
+    <h1>Verify Your Identity</h1>
+    <AlertBox content="You signed in with Login.gov" isVisible status="success"/>
+    <p>We'll need to verify your identity so that you can securely access and manage your data.</p>
+    <p>This one-time process will take <strong>5 - 10 minutes</strong> to complete</p>
+    <a class="no-external-icon usa-button login-gov" href="{{ login_gov_login_link }}"><img alt="Login.gov" src="/samlproxy/idp/img/login-gov-logo.svg" />Verify with Login.gov</a>
+    <h4>Having trouble verifying your identity?</h4>
+    <p><a href="https://staging.va.gov/sign-in-faq/">Get answers to Frequently Asked Questions</a></p>
+    <p>
+      Or call MyVA311 for help: <a href="tel:18446982311">1-844-698-2311</a>. If you have hearing loss, call TTY: 711
+    </p>
+    <p>We're here Monday &ndash; Friday, 8:00 a.m. &ndash; 8:00 p.m. (ET)</p>
+  </div>
+</div>

--- a/views/failureToProof.hbs
+++ b/views/failureToProof.hbs
@@ -1,7 +1,6 @@
 <div class="usa-grid idme-signup-footer">
   <div class="usa">
     <h1>Verify Your Identity</h1>
-    <AlertBox content="You signed in with Login.gov" isVisible status="success"/>
     <p>We'll need to verify your identity so that you can securely access and manage your data.</p>
     <p>This one-time process will take <strong>5 - 10 minutes</strong> to complete</p>
     <a class="no-external-icon usa-button login-gov" href="{{ login_gov_login_link }}"><img alt="Login.gov" src="/samlproxy/idp/img/login-gov-logo.svg" />Verify with Login.gov</a>


### PR DESCRIPTION
https://vajira.max.gov/browse/API-11123

Adds support for the failure to proof flow with Login.gov.  To isolate the changes, this defers consolidation of the ID.me federated logins and Login.gov flow.

Login.gov enforces minimum IAL during the login.  This is automatic when logging in with an account that has not yet been identity proofed.  Sandbox url: https://idp.int.identitysandbox.gov/verify/doc_auth/welcome
![image](https://user-images.githubusercontent.com/43859081/143099444-28866522-a6e0-4178-98f6-d138ee9dad7a.png)



If an IAL1 user cancels the proofing flow, they are returned to the Lighthouse SAML Proxy where we encourage completion of the proofing process in order to access Lighthouse API's.
![image](https://user-images.githubusercontent.com/43859081/143090670-70980fa9-e578-43f9-94c9-75386a8ccd4c.png)
