### PR TITLE
API-12695 force authn

### DIFF
--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -47,6 +47,9 @@ export default class SPConfig {
     this.failureFlash = true;
     this.category = argv.category || "id_me";
     this.signupLinkEnabled = argv.spIdpSignupLinkEnabled;
+    if (argv.disabled) {
+      this.disabled = argv.disabled;
+    }
   }
 
   getMetadataParams(req) {

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -63,14 +63,11 @@ export const samlLogin = function (template) {
       );
     });
 
-    let login_gov_enabled;
-    if (
-      (req.sps.options.logingov && !req.sps.options.logingov.disabled) ||
-      authnRequest.forceAuthn
-    ) {
-      login_gov_enabled = true;
-    } else {
-      login_gov_enabled = false;
+    let login_gov_enabled = false;
+    if (req.sps.options.logingov) {
+      if (!req.sps.options.logingov.disabled || authnRequest.forceAuthn) {
+        login_gov_enabled = true;
+      }
     }
 
     const authnSelection = [

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -64,7 +64,10 @@ export const samlLogin = function (template) {
     });
 
     let login_gov_enabled;
-    if (req.sps.options.logingov && !req.sps.options.logingov.disabled) {
+    if (
+      (req.sps.options.logingov && !req.sps.options.logingov.disabled) ||
+      authnRequest.forceAuthn
+    ) {
       login_gov_enabled = true;
     } else {
       login_gov_enabled = false;

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -64,7 +64,7 @@ export const samlLogin = function (template) {
     });
 
     let login_gov_enabled;
-    if (req.sps.options.logingov) {
+    if (req.sps.options.logingov && !req.sps.options.logingov.disabled) {
       login_gov_enabled = true;
     } else {
       login_gov_enabled = false;


### PR DESCRIPTION
- Temporary use of forceAuthn flag to enable the LoginGov IDP via the auth request
  - This is for login.gov testing in prod prior to activation
- This is a draft PR with an alternative approach in mind us