### PR TITLE
API-12695 relay state

### DIFF
--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -50,6 +50,9 @@ export default class SPConfig {
     if (argv.disabled) {
       this.disabled = argv.disabled;
     }
+    if (argv.relayStateActivation) {
+      this.relayStateActivation = argv.relayStateActivation;
+    }
   }
 
   getMetadataParams(req) {

--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -47,6 +47,9 @@ export default class SPConfig {
     this.failureFlash = true;
     this.category = argv.category || "id_me";
     this.signupLinkEnabled = argv.spIdpSignupLinkEnabled;
+    if (argv.disabled) {
+      this.disabled = argv.disabled;
+    }
   }
 
   getMetadataParams(req) {

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -64,7 +64,7 @@ export const samlLogin = function (template) {
     });
 
     let login_gov_enabled;
-    if (req.sps.options.logingov) {
+    if (req.sps.options.logingov && !req.sps.options.logingov.disabled) {
       login_gov_enabled = true;
     } else {
       login_gov_enabled = false;

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -63,11 +63,15 @@ export const samlLogin = function (template) {
       );
     });
 
-    let login_gov_enabled;
-    if (req.sps.options.logingov && !req.sps.options.logingov.disabled) {
-      login_gov_enabled = true;
-    } else {
-      login_gov_enabled = false;
+    let login_gov_enabled = false;
+    if (req.sps.options.logingov) {
+      if (
+        !req.sps.options.logingov.disabled ||
+        (req.sps.options.logingov.relayStateActivation &&
+          relayState.includes(req.sps.options.logingov.relayStateActivation))
+      ) {
+        login_gov_enabled = true;
+      }
     }
 
     const authnSelection = [


### PR DESCRIPTION
- Temporary use of a matching phrase in the RelayState to enable the LoginGov IDP via the auth request
  - This is for login.gov testing in prod prior to activation
- This is approach nominated for enabling the login.gov idp via the auth  request

Example config segment:
```
{
   .
   .
   .
   "idpSamlLoginsEnabled": true,
    "idpSelectionRefactor" : true,
    "idpSamlLogins": 
      [
        {
          "category": "logingov",
          "disabled": true,
          "relayStateActivation": "xxxxxxxx",
          "spIdpMetaUrl": "https://idp.int.identitysandbox.gov/api/saml/metadata2021",
          "spNameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
          "spAudience": "urn:gov:gsa:SAML:2.0.profiles:sp:sso:va_lighthouse:saml_proxy_local",
          "spRequestAuthnContext": true,
          "spRequestNameIDFormat": true,
          "spCert": "./sp-cert.pem",
          "spKey": "./sp-key.pem",
          "spProtocol": "samlp",
          "spAuthnContextClassRef": "http://idmanagement.gov/ns/assurance/ial/2",
          "spIdpSignupLinkEnabled": true
        }
      ]
  }
```