### PR TITLE
API-12695 cookie activation

### DIFF
--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -50,8 +50,8 @@ export default class SPConfig {
     if (argv.disabled) {
       this.disabled = argv.disabled;
     }
-    if (argv.relayStateActivation) {
-      this.relayStateActivation = argv.relayStateActivation;
+    if (argv.idpActivationCookie) {
+      this.idpActivationCookie = argv.idpActivationCookie;
     }
   }
 

--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -50,6 +50,9 @@ export default class SPConfig {
     if (argv.disabled) {
       this.disabled = argv.disabled;
     }
+    if (argv.relayStateActivation) {
+      this.relayStateActivation = argv.relayStateActivation;
+    }
   }
 
   getMetadataParams(req) {

--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -47,8 +47,11 @@ export default class SPConfig {
     this.failureFlash = true;
     this.category = argv.category || "id_me";
     this.signupLinkEnabled = argv.spIdpSignupLinkEnabled;
-    if (argv.disabled) {
-      this.disabled = argv.disabled;
+    if (argv.idpTemporarilyDisabled) {
+      // Disables the idpConfig as an IPP login option
+      // This is needed to provide an option for using a runtime flag,
+      //  eg: cookie in order to activate for testing
+      this.idpTemporarilyDisabled = argv.idpTemporarilyDisabled;
     }
     if (argv.idpActivationCookie) {
       this.idpActivationCookie = argv.idpActivationCookie;

--- a/src/SPConfig.js
+++ b/src/SPConfig.js
@@ -47,6 +47,9 @@ export default class SPConfig {
     this.failureFlash = true;
     this.category = argv.category || "id_me";
     this.signupLinkEnabled = argv.spIdpSignupLinkEnabled;
+    if (argv.disabled) {
+      this.disabled = argv.disabled;
+    }
   }
 
   getMetadataParams(req) {

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -211,10 +211,7 @@ function enabled_logingov(req) {
     if (
       !req.sps.options.logingov.idpTemporarilyDisabled ||
       (req.sps.options.logingov.idpActivationCookie &&
-        req.cookies[req.sps.options.logingov.idpActivationCookie] &&
-        req.cookies[req.sps.options.logingov.idpActivationCookie].includes(
-          req.sps.options.logingov.category
-        ))
+        req.cookies[req.sps.options.logingov.idpActivationCookie])
     ) {
       login_gov_enabled = true;
     }

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -209,7 +209,7 @@ function enabled_logingov(req) {
   req.cookies;
   if (req.sps.options.logingov) {
     if (
-      !req.sps.options.logingov.disabled ||
+      !req.sps.options.logingov.idpTemporarilyDisabled ||
       (req.sps.options.logingov.idpActivationCookie &&
         req.cookies[req.sps.options.logingov.idpActivationCookie] &&
         req.cookies[req.sps.options.logingov.idpActivationCookie].includes(

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -64,7 +64,7 @@ export const samlLogin = function (template) {
     });
 
     let login_gov_enabled;
-    if (req.sps.options.logingov) {
+    if (req.sps.options.logingov && !req.sps.options.logingov.disabled) {
       login_gov_enabled = true;
     } else {
       login_gov_enabled = false;

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -63,16 +63,7 @@ export const samlLogin = function (template) {
       );
     });
 
-    let login_gov_enabled = false;
-    if (req.sps.options.logingov) {
-      if (
-        !req.sps.options.logingov.disabled ||
-        (req.sps.options.logingov.relayStateActivation &&
-          relayState.includes(req.sps.options.logingov.relayStateActivation))
-      ) {
-        login_gov_enabled = true;
-      }
-    }
+    let login_gov_enabled = enabled_logingov(req, relayState);
 
     const authnSelection = [
       ["id_me_login_link", "http://idmanagement.gov/ns/assurance/loa/3"],
@@ -212,3 +203,21 @@ export const handleError = (req, res) => {
   logger.error({ idp_sid: req.cookies.idp_sid });
   res.render(urlUserErrorTemplate(req), { request_id: rTracer.id() });
 };
+
+function enabled_logingov(req) {
+  let login_gov_enabled = false;
+  req.cookies;
+  if (req.sps.options.logingov) {
+    if (
+      !req.sps.options.logingov.disabled ||
+      (req.sps.options.logingov.idpActivationCookie &&
+        req.cookies[req.sps.options.logingov.idpActivationCookie] &&
+        req.cookies[req.sps.options.logingov.idpActivationCookie].includes(
+          req.sps.options.logingov.category
+        ))
+    ) {
+      login_gov_enabled = true;
+    }
+  }
+  return login_gov_enabled;
+}

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -63,11 +63,15 @@ export const samlLogin = function (template) {
       );
     });
 
-    let login_gov_enabled;
-    if (req.sps.options.logingov && !req.sps.options.logingov.disabled) {
-      login_gov_enabled = true;
-    } else {
-      login_gov_enabled = false;
+    let login_gov_enabled = false;
+    if (req.sps.options.logingov) {
+      if (
+        !req.sps.options.logingov.disabled ||
+        (req.sps.options.logingov.relayStateActivation &&
+          relayState.includes(req.sps.options.logingov.relayStateActivation))
+      ) {
+        login_gov_enabled = true;
+      }
     }
 
     const authnSelection = [

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -63,7 +63,7 @@ export const samlLogin = function (template) {
       );
     });
 
-    let login_gov_enabled = enabled_logingov(req, relayState);
+    let login_gov_enabled = enabled_logingov(req);
 
     const authnSelection = [
       ["id_me_login_link", "http://idmanagement.gov/ns/assurance/loa/3"],
@@ -206,7 +206,6 @@ export const handleError = (req, res) => {
 
 function enabled_logingov(req) {
   let login_gov_enabled = false;
-  req.cookies;
   if (req.sps.options.logingov) {
     if (
       !req.sps.options.logingov.idpTemporarilyDisabled ||

--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -210,6 +210,7 @@ function enabled_logingov(req) {
     if (
       !req.sps.options.logingov.idpTemporarilyDisabled ||
       (req.sps.options.logingov.idpActivationCookie &&
+        req.cookies &&
         req.cookies[req.sps.options.logingov.idpActivationCookie])
     ) {
       login_gov_enabled = true;

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -272,6 +272,19 @@ describe("samlLogin", () => {
       "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
   };
 
+  const expected_authoptions_login_gov_disabled = {
+    id_me_login_link:
+      "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
+    dslogon_login_link:
+      "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
+    mhv_login_link:
+      "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=",
+    id_me_signup_link:
+      "https://identityProviderUrl.com?SAMLRequest=utrequest&RelayState=&op=signup",
+    login_gov_enabled: false,
+    login_gov_signup_link_enabled: false,
+  };
+
   const mockGetSamlRequestUrl = jest
     .fn()
     .mockImplementation((opts, callback) => {
@@ -371,6 +384,34 @@ describe("samlLogin", () => {
       return promise2check(
         "login_selection",
         expected_authoptions_login_gov_enabled,
+        template,
+        authOptions
+      );
+    };
+
+    samlp.mockImplementation(() => {
+      return {
+        getSamlRequestUrl: mockGetSamlRequestUrl,
+      };
+    });
+    const doLogin = samlLogin("login_selection");
+    try {
+      doLogin(mockRequest, mockResponse, mockNext);
+    } catch (err) {
+      fail("Should not reach here");
+    }
+  });
+
+  it("Happy Path login_gov_cookie_disabled", async () => {
+    mockRequest.authnRequest = {
+      relayState: "theRelayState",
+    };
+
+    mockRequest.sps.options = spOptionsJustwithLoginGovCookie;
+    mockResponse.render = function render(template, authOptions) {
+      return promise2check(
+        "login_selection",
+        expected_authoptions_login_gov_disabled,
         template,
         authOptions
       );

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -179,6 +179,47 @@ describe("samlLogin", () => {
       },
     },
   };
+  const spOptionsJustwithLoginGovCookie = {
+    id_me: {
+      idpLoginLink:
+        "https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=fVJNTwIxED37Lza9s13BaGxYAoGYkOBHQD14G8sITfqxdmYR%2F73dZSEc1GQP3c57M%2B%2B96ZDA2UpNat76JX7WSJztnfWk2kIp6uhVADKkPDgkxVqtJvcL1c8LVcXAQQcrzij%2FM4AII5vgRTaflWI8ns%2FG43QmqnHuicFzKfpFv%2BgVt71i8Hx5ra7Sd%2FsmsovJkTsNnmqHcYVxZzS%2BLBel2DJXSkobNNhtIFY3RVHI1kMM%2B29JVfsjiYK4mCWXxkPT68CkRIXK5Gbt0MI75Tq4A35l%2FMbiymz8o%2B%2FmiewVI7XcZElkdyFqbAMsBccaxWjYUFVrKo5OGvIdbMIuX%2BNuKM8Bw8MKHlJY89lTsEZ%2FNz0d8P9ZNjdm3ftooapqNBGjZ5FNrA1f04jA2EmSxyndjnHdCk5JMu45mwZXQTTUeMI9aD56OEdNbdreEj9GXdYpLPCwQZdm5smZ9CQToo7gNaZNgBx0Rn%2Ftcqj9oehUPX%2BYox8%3D&RelayState=%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=crqsP27LiAeJpKx7%2Bjshr4OeqHvFnp1rYmkP4rHTYXdEIjp6iIo7Zu3uwzXfkm%2BJp0ShXPAy7R6855y1dMBmOz3eVjdvdm8rQ7%2B044hTw3Cxmcuf836up4rsKLeT4vIHc3%2FA3qtDK3ut%2FXiArNLZJ%2FwOrC6KNWAuhJQ8fZIPv18uiCw1eNBJA2iCUD6KKtI%2FDgwA%2B1MtpRCsHNcpX23XQryIPkH8l6MsRDw1ZM3vttF7UZa6OkIsxFEXFJ4VZMal%2BciNZV%2FiB0%2FK3QvmbbKX8k%2BuJKL8rmIJr0XhNw%2BYLcMTNnpL%2FTQloi0xS18gu3J6GY%2BTEsG1CeJRNHkuJyF3LQ%3D%3D",
+      getResponseParams: () => {
+        return {
+          thumbprint: "thumbprint",
+        };
+      },
+      getAuthnRequestParams: () => {
+        return {
+          identityProviderUrl: "https://identityProviderUrl.com",
+          id_me_login_link:
+            "https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=fVJNTwIxED37Lza9s13BaGxYAoGYkOBHQD14G8sITfqxdmYR%2F73dZSEc1GQP3c57M%2B%2B96ZDA2UpNat76JX7WSJztnfWk2kIp6uhVADKkPDgkxVqtJvcL1c8LVcXAQQcrzij%2FM4AII5vgRTaflWI8ns%2FG43QmqnHuicFzKfpFv%2BgVt71i8Hx5ra7Sd%2FsmsovJkTsNnmqHcYVxZzS%2BLBel2DJXSkobNNhtIFY3RVHI1kMM%2B29JVfsjiYK4mCWXxkPT68CkRIXK5Gbt0MI75Tq4A35l%2FMbiymz8o%2B%2FmiewVI7XcZElkdyFqbAMsBccaxWjYUFVrKo5OGvIdbMIuX%2BNuKM8Bw8MKHlJY89lTsEZ%2FNz0d8P9ZNjdm3ftooapqNBGjZ5FNrA1f04jA2EmSxyndjnHdCk5JMu45mwZXQTTUeMI9aD56OEdNbdreEj9GXdYpLPCwQZdm5smZ9CQToo7gNaZNgBx0Rn%2Ftcqj9oehUPX%2BYox8%3D&RelayState=%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=crqsP27LiAeJpKx7%2Bjshr4OeqHvFnp1rYmkP4rHTYXdEIjp6iIo7Zu3uwzXfkm%2BJp0ShXPAy7R6855y1dMBmOz3eVjdvdm8rQ7%2B044hTw3Cxmcuf836up4rsKLeT4vIHc3%2FA3qtDK3ut%2FXiArNLZJ%2FwOrC6KNWAuhJQ8fZIPv18uiCw1eNBJA2iCUD6KKtI%2FDgwA%2B1MtpRCsHNcpX23XQryIPkH8l6MsRDw1ZM3vttF7UZa6OkIsxFEXFJ4VZMal%2BciNZV%2FiB0%2FK3QvmbbKX8k%2BuJKL8rmIJr0XhNw%2BYLcMTNnpL%2FTQloi0xS18gu3J6GY%2BTEsG1CeJRNHkuJyF3LQ%3D%3D",
+          dslogon_login_link:
+            "https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=fVLLboMwEDznL5DvAZpWrWIFRASqhJQ%2BlLQ99ObCJrFkvNS7pMnfF8hDHNpIPtjeGe%2FMrGekKlPLecNbu4TvBoi9fWUsyb4QicZZiYo0SasqIMmFXM2fFnLih7J2yFigEQPKdYYiAscarfDyLBJJkmdJ0u6JGsgtsbIciUk4CcfhdBzevt3cy7t2TT%2BFN5qfuSlaaipwK3A7XcD7chGJLXMtg8BgocwWieVDGIZB78Hh%2FhBQ3R8CIhSjrHWprereOjKppapa%2B7qswKgv8gusjviVthsDK72xL%2FbUT3gf4KjntpaE94iugD7ASLBrQMSzjip7Uy6%2BaPB3aoM7v4TdLBgCZscRPLdh5dkrGl0cujcrxdez7G50OV73UFl3mojBsvDmxuBP6kAxnCQF5y6nGUPZC26TZNizl2JVK6ep8wR7VfDZwxCVmnZ6S1jHJRncoD25%2BBNyrP3T7lId%2Frr4Fw%3D%3D&RelayState=%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=bkKD3IEEtf7GErOTAkv6iYxgQF9UGcg1M%2BrZvuMvRXzaSz9Y2uQSWfsYT7m4x0ZU1JbNYsavwHLxAT%2BjwxcMSriLg4ywT0oa50dMwIlKih9IlUJgRvxHXsDYR8s%2B%2F%2BqH6JZYgCJO%2Fmxbam2UMJTqAn3MkheVXxMTCVNRre5%2FL56Eh8EEsf8j%2F9BqUIMA8kxlCgiOoC08nr0%2FEx6kmBYdvywat4RE7jiFKT1lce3U4t0n28fOu%2BfrQCyvtaRZoIMRGIRWxtLh5CaSU6jn%2Fwvfzei45%2FxWHW5W2noUDjCXbIDr4QMUNl5aePQn5jOVWYeNdkyp4CTq1%2FgyFsXW1k3M3A%3D%3D",
+          mvh_login_link:
+            "https://api.idmelabs.com/saml/SingleSignOnService?SAMLRequest=fVLLbsIwEDzzF5HvJCmtWmERFERUKRJ9iLQ99OYmC7HkR%2BrdpOHvmwcgDi2SD7Z3xjsz6wUKrSq%2Bqqk0W%2FiuAclrtTLIh0LEame4FSiRG6EBOeU8Wz1t%2BMwPeeUs2dwqdkG5zhCI4Ehaw7w0iVgcp0kcd3vEGlKDJAxFbBbOwmk4n4a3bzf3%2FK5b80%2FmTVYn7toarDW4DFwjc3jfbiJWElU8CJTNhSotEn8IwzAYPDjbHgKshkOAaNkk6VxKI%2Fq3RiZ2VFFJXxYalPhCP7d6xGfS7BVkcm9ezLEf8z7A4cDtLDHv0bochgAjRq4Gtlz0VD6YcsuzBr8Re9v4BTSL4BKwGEfw3IWVJq9WyfzQv6kFXc%2Byv5HFdDdAedVrQgJDzFspZX%2FWDgTBUVJw6nKcMRSD4C5Jgpa8tdWVcBJ7T9CKnE4eLlFr1U1vC7ulPpQgFJXQAB2t%2FIkba%2F%2F0PFcvv97yFw%3D%3D&RelayState=%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=AtPbhLpittfvJLCw19J3u8Vq6UvBG7maFggSQM6vCTKCdB%2FAhCXk0P0drEk4OS0RNk2dZ8yVOfTeJ85874Re5VL%2BRKiUDd751U0VhSdlVkz%2Bl%2BeCmK%2FJzq8%2F9G5tgwjJbBk2Z6WBQlSspsfYBUetm%2B77NfI%2BPHjiusVXelk7t6cKAXV81YHyuwCgXaw2Y%2BxeUS8pna5W4zult1V4vE0YLpSyOnQbAeGLXygqmcuSlm%2BR0%2BTZsatYEve%2BubTxCXy58gE8ab3VhSjuasu%2BLiby8kJUpF95Shuhv58YyDYRx%2BtgJ9%2BDBit%2F4vB5MkvhYpDpIYXpYxBPo%2Ftv2fSqmLjU1Q%3D%3D",
+        };
+      },
+    },
+    logingov: {
+      idpLoginLink:
+        "https://idp.int.identitysandbox.gov/api/saml/metadata2021?SAMLRequest=fVJNTwIxED37Lza9s13BaGxYAoGYkOBHQD14G8sITfqxdmYR%2F73dZSEc1GQP3c57M%2B%2B96ZDA2UpNat76JX7WSJztnfWk2kIp6uhVADKkPDgkxVqtJvcL1c8LVcXAQQcrzij%2FM4AII5vgRTaflWI8ns%2FG43QmqnHuicFzKfpFv%2BgVt71i8Hx5ra7Sd%2FsmsovJkTsNnmqHcYVxZzS%2BLBel2DJXSkobNNhtIFY3RVHI1kMM%2B29JVfsjiYK4mCWXxkPT68CkRIXK5Gbt0MI75Tq4A35l%2FMbiymz8o%2B%2FmiewVI7XcZElkdyFqbAMsBccaxWjYUFVrKo5OGvIdbMIuX%2BNuKM8Bw8MKHlJY89lTsEZ%2FNz0d8P9ZNjdm3ftooapqNBGjZ5FNrA1f04jA2EmSxyndjnHdCk5JMu45mwZXQTTUeMI9aD56OEdNbdreEj9GXdYpLPCwQZdm5smZ9CQToo7gNaZNgBx0Rn%2Ftcqj9oehUPX%2BYox8%3D&RelayState=%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=crqsP27LiAeJpKx7%2Bjshr4OeqHvFnp1rYmkP4rHTYXdEIjp6iIo7Zu3uwzXfkm%2BJp0ShXPAy7R6855y1dMBmOz3eVjdvdm8rQ7%2B044hTw3Cxmcuf836up4rsKLeT4vIHc3%2FA3qtDK3ut%2FXiArNLZJ%2FwOrC6KNWAuhJQ8fZIPv18uiCw1eNBJA2iCUD6KKtI%2FDgwA%2B1MtpRCsHNcpX23XQryIPkH8l6MsRDw1ZM3vttF7UZa6OkIsxFEXFJ4VZMal%2BciNZV%2FiB0%2FK3QvmbbKX8k%2BuJKL8rmIJr0XhNw%2BYLcMTNnpL%2FTQloi0xS18gu3J6GY%2BTEsG1CeJRNHkuJyF3LQ%3D%3D",
+      getResponseParams: () => {
+        return {
+          thumbprint: "thumbprint",
+        };
+      },
+      signupLinkEnabled: true,
+      getAuthnRequestParams: () => {
+        return {
+          identityProviderUrl: "https://idp.int.identitysandbox.gov/api/saml",
+          login_gov_login_link:
+            "https://idp.int.identitysandbox.gov/api/saml/metadata2021?SAMLRequest=fVJNTwIxED37Lza9s13BaGxYAoGYkOBHQD14G8sITfqxdmYR%2F73dZSEc1GQP3c57M%2B%2B96ZDA2UpNat76JX7WSJztnfWk2kIp6uhVADKkPDgkxVqtJvcL1c8LVcXAQQcrzij%2FM4AII5vgRTaflWI8ns%2FG43QmqnHuicFzKfpFv%2BgVt71i8Hx5ra7Sd%2FsmsovJkTsNnmqHcYVxZzS%2BLBel2DJXSkobNNhtIFY3RVHI1kMM%2B29JVfsjiYK4mCWXxkPT68CkRIXK5Gbt0MI75Tq4A35l%2FMbiymz8o%2B%2FmiewVI7XcZElkdyFqbAMsBccaxWjYUFVrKo5OGvIdbMIuX%2BNuKM8Bw8MKHlJY89lTsEZ%2FNz0d8P9ZNjdm3ftooapqNBGjZ5FNrA1f04jA2EmSxyndjnHdCk5JMu45mwZXQTTUeMI9aD56OEdNbdreEj9GXdYpLPCwQZdm5smZ9CQToo7gNaZNgBx0Rn%2Ftcqj9oehUPX%2BYox8%3D&RelayState=%2F&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=crqsP27LiAeJpKx7%2Bjshr4OeqHvFnp1rYmkP4rHTYXdEIjp6iIo7Zu3uwzXfkm%2BJp0ShXPAy7R6855y1dMBmOz3eVjdvdm8rQ7%2B044hTw3Cxmcuf836up4rsKLeT4vIHc3%2FA3qtDK3ut%2FXiArNLZJ%2FwOrC6KNWAuhJQ8fZIPv18uiCw1eNBJA2iCUD6KKtI%2FDgwA%2B1MtpRCsHNcpX23XQryIPkH8l6MsRDw1ZM3vttF7UZa6OkIsxFEXFJ4VZMal%2BciNZV%2FiB0%2FK3QvmbbKX8k%2BuJKL8rmIJr0XhNw%2BYLcMTNnpL%2FTQloi0xS18gu3J6GY%2BTEsG1CeJRNHkuJyF3LQ%3D%3D",
+        };
+      },
+      idpTemporarilyDisabled: true,
+      idpActivationCookie: "crunchycookie",
+    },
+  };
   beforeEach(() => {
     mockResponse = {
       render: jest.fn(),
@@ -297,6 +338,35 @@ describe("samlLogin", () => {
 
     mockRequest.sps.options = spOptionsJustwithLoginGov;
 
+    mockResponse.render = function render(template, authOptions) {
+      return promise2check(
+        "login_selection",
+        expected_authoptions_login_gov_enabled,
+        template,
+        authOptions
+      );
+    };
+
+    samlp.mockImplementation(() => {
+      return {
+        getSamlRequestUrl: mockGetSamlRequestUrl,
+      };
+    });
+    const doLogin = samlLogin("login_selection");
+    try {
+      doLogin(mockRequest, mockResponse, mockNext);
+    } catch (err) {
+      fail("Should not reach here");
+    }
+  });
+
+  it("Happy Path login_gov_cookie_enabled", async () => {
+    mockRequest.authnRequest = {
+      relayState: "theRelayState",
+    };
+
+    mockRequest.sps.options = spOptionsJustwithLoginGovCookie;
+    mockRequest.cookies = { crunchycookie: "whatever" };
     mockResponse.render = function render(template, authOptions) {
       return promise2check(
         "login_selection",


### PR DESCRIPTION
- Temporary use of a matching cookie to enable the LoginGov IDP via the auth request
  - This is for login.gov testing in prod prior to activation
- This is approach nominated for enabling the login.gov idp via the auth  request

Example config segment:
```
{
   .
   .
   .
   "idpSamlLoginsEnabled": true,
    "idpSelectionRefactor" : true,
    "idpSamlLogins": 
      [
        {
          "category": "logingov",
          "idpTemporarilyDisabled": true,
          "idpActivationCookie": "doublestuffedoreo",
          "spIdpMetaUrl": "https://idp.int.identitysandbox.gov/api/saml/metadata2021",
          "spNameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
          "spAudience": "urn:gov:gsa:SAML:2.0.profiles:sp:sso:va_lighthouse:saml_proxy_local",
          "spRequestAuthnContext": true,
          "spRequestNameIDFormat": true,
          "spCert": "./sp-cert.pem",
          "spKey": "./sp-key.pem",
          "spProtocol": "samlp",
          "spAuthnContextClassRef": "http://idmanagement.gov/ns/assurance/ial/2",
          "spIdpSignupLinkEnabled": true
        }
      ]
  }
```