### PR TITLE
Choose active signing key if more than 1

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -24,10 +24,17 @@ const handleMetadata = (argv) => {
   return (metadata) => {
     if (metadata.protocol) {
       argv.spProtocol = metadata.protocol;
-      if (metadata.signingKeys[0]) {
-        argv.spIdpCert = cli.certToPEM(metadata.signingKeys[0]);
+      if (metadata.signingKeys) {
+        var signingKeyCert;
+        signingKeyCert = metadata.signingKeys.find(
+          (sKeyCert) => sKeyCert.active === true
+        );
+        if (signingKeyCert) {
+          argv.spIdpCert = cli.certToPEM(signingKeyCert.cert);
+        } else if (metadata.signingKeys[0]) {
+          argv.spIdpCert = cli.certToPEM(metadata.signingKeys[0].cert);
+        }
       }
-
       switch (metadata.protocol) {
         case "samlp":
           if (metadata.sso.redirectUrl) {

--- a/src/idpMetadata.js
+++ b/src/idpMetadata.js
@@ -67,7 +67,12 @@ export function fetch(url) {
 
             ssoEl.KeyDescriptor.forEach((keyEl) => {
               if (keyEl.$.use && keyEl.$.use.toLowerCase() !== "encryption") {
-                metadata.signingKeys.push(getFirstCert(keyEl));
+                const signingKey = {};
+                signingKey.cert = getFirstCert(keyEl);
+                if (keyEl.$.active && keyEl.$.active === "true") {
+                  signingKey.active = true;
+                }
+                metadata.signingKeys.push(signingKey);
               }
             });
 


### PR DESCRIPTION
Choose the signing key marked as active if more than 1 is available in the IDP metadata