### PR TITLE
API-000-clean-up-from-code-review

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -25,7 +25,7 @@ const handleMetadata = (argv) => {
     if (metadata.protocol) {
       argv.spProtocol = metadata.protocol;
       if (metadata.signingKeys) {
-        var signingKeyCert;
+        let signingKeyCert;
         signingKeyCert = metadata.signingKeys.find(
           (sKeyCert) => sKeyCert.active === true
         );


### PR DESCRIPTION
Follow up clean up for scoping `var` vs `let`.

https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/pull/384#discussion_r815951030