### PR TITLE
API-13140 Upgrade Node-Forge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6170,9 +6170,7 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+      "version": ">=1.0.0",
       "engines": {
         "node": ">= 6.0.0"
       }
@@ -15337,9 +15335,7 @@
       }
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": ">=1.0.0"
     },
     "node-int64": {
       "version": "0.4.0",
@@ -15660,7 +15656,7 @@
         "@auth0/xmldom": "0.1.22",
         "ejs": "2.5.5",
         "jsonwebtoken": "~5.0.4",
-        "node-forge": "^0.10.0",
+        "node-forge": ">=1.0.0",
         "passport-strategy": "^1.0.0",
         "uid2": "0.0.x",
         "valid-url": "^1.0.9",
@@ -15670,6 +15666,9 @@
         "xtend": "~2.0.3"
       },
       "dependencies": {
+        "node-forge": {
+          "version": ">=1.0.0"
+        },
         "xml-crypto": {
           "version": ">=2.1.3"
         }
@@ -17566,10 +17565,13 @@
       "requires": {
         "@xmldom/xmldom": "^0.7.0",
         "escape-html": "^1.0.3",
-        "node-forge": "^0.10.0",
+        "node-forge": ">=1.0.0",
         "xpath": "0.0.32"
       },
       "dependencies": {
+        "node-forge": {
+          "version": ">=1.0.0"
+        },
         "xpath": {
           "version": "0.0.32",
           "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "trim-newlines": ">=3.0.1",
     "normalize-url": "4.5.1",
     "http-signature": ">=1.3.6",
-    "json-schema": ">=0.4.0"
+    "json-schema": ">=0.4.0",
+    "node-forge": ">=1.0.0"
   }
 }

--- a/test/regression_tests/package.json
+++ b/test/regression_tests/package.json
@@ -4,6 +4,7 @@
   "description": "Saml Proxy regression tests.",
   "main": "saml-proxy-regression.test.js",
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "test": "jest -- saml-proxy-regression.test.js"
   },
   "keywords": [
@@ -18,5 +19,8 @@
     "saml-attacks": "github:department-of-veterans-affairs/lighthouse-saml-utils",
     "saml-encoder-decoder-js": "^1.0.1",
     "uuid": "^8.3.2"
+  },
+  "resolutions": {
+    "node-forge": ">=1.0.0"
   }
 }


### PR DESCRIPTION
Upgrade node-forge package at least v1.0.0 to remove security vulnerabilities.

Issue: https://vajira.max.gov/browse/API-13140