### PR TITLE
added error handler to log passport auth failure

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -27,16 +27,14 @@ const handleMetadata = (argv) => {
       if (metadata.signingKeys) {
         let signingKeyCert;
         signingKeyCert = metadata.signingKeys.find(
-          (sKeyCert) => !sKeyCert.active
+          (sKeyCert) => sKeyCert.active === true
         );
         if (signingKeyCert) {
           //id.me
           argv.spIdpCert = cli.certToPEM(signingKeyCert.cert);
-        } else if (metadata.signingKeys[1]) {
+        } else if (metadata.signingKeys[0]) {
           // normally login.gov
-          argv.spIdpCert = cli.certToPEM(metadata.signingKeys[1].cert);
-          logger.info("Cert misalignment error");
-          logger.info(`Metadata protocol ${metadata.protocol}`);
+          argv.spIdpCert = cli.certToPEM(metadata.signingKeys[0].cert);
         }
       }
       switch (metadata.protocol) {
@@ -121,10 +119,6 @@ function runServer(argv) {
 }
 
 function main() {
-  // let argv = cli.processArgs();
-  // setInterval(() => {
-  //   runServer(cli.processArgs());
-  // }, 3000);
   runServer(cli.processArgs());
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -27,12 +27,16 @@ const handleMetadata = (argv) => {
       if (metadata.signingKeys) {
         let signingKeyCert;
         signingKeyCert = metadata.signingKeys.find(
-          (sKeyCert) => sKeyCert.active === true
+          (sKeyCert) => !sKeyCert.active
         );
         if (signingKeyCert) {
+          //id.me
           argv.spIdpCert = cli.certToPEM(signingKeyCert.cert);
-        } else if (metadata.signingKeys[0]) {
-          argv.spIdpCert = cli.certToPEM(metadata.signingKeys[0].cert);
+        } else if (metadata.signingKeys[1]) {
+          // normally login.gov
+          argv.spIdpCert = cli.certToPEM(metadata.signingKeys[1].cert);
+          logger.info("Cert misalignment error");
+          logger.info(`Metadata protocol ${metadata.protocol}`);
         }
       }
       switch (metadata.protocol) {
@@ -117,6 +121,10 @@ function runServer(argv) {
 }
 
 function main() {
+  // let argv = cli.processArgs();
+  // setInterval(() => {
+  //   runServer(cli.processArgs());
+  // }, 3000);
   runServer(cli.processArgs());
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -25,15 +25,14 @@ const handleMetadata = (argv) => {
     if (metadata.protocol) {
       argv.spProtocol = metadata.protocol;
       if (metadata.signingKeys) {
+        // different provider metadata notation requires look up by an active key or falling back to the first entry by default
         let signingKeyCert;
         signingKeyCert = metadata.signingKeys.find(
           (sKeyCert) => sKeyCert.active === true
         );
         if (signingKeyCert) {
-          //id.me
           argv.spIdpCert = cli.certToPEM(signingKeyCert.cert);
         } else if (metadata.signingKeys[0]) {
-          // normally login.gov
           argv.spIdpCert = cli.certToPEM(metadata.signingKeys[0].cert);
         }
       }

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -1,4 +1,4 @@
-import { SP_VERIFY } from "./constants";
+import { SP_VERIFY, SP_ERROR_URL } from "./constants";
 import { getReqUrl, logRelayState } from "../utils";
 import { ICache, IConfiguredRequest } from "./types";
 import { preparePassport } from "./passport";
@@ -69,7 +69,7 @@ export const buildPassportLoginHandler = (acsURL: string) => {
       if (err.message) {
         logger.error(err.message);
         logger.error(status);
-        return res.redirect("/samlproxy/sp/error");
+        return res.redirect(SP_ERROR_URL);
       }
       // userInfo contains the user object returned from the SAML identity provider,
       // in this case the happy path should simply pass forward the user identity

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -61,7 +61,7 @@ const sufficientLevelOfAssurance = (claims: any) => {
 export const buildPassportLoginHandler = (acsURL: string) => {
   return (req: IConfiguredRequest, res: Response, next: NextFunction) => {
     const authenticateCallBack = (
-      arg1: any,
+      _1: any,
       userInfo: any,
       err: any,
       status: any

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -60,6 +60,12 @@ const sufficientLevelOfAssurance = (claims: any) => {
 
 export const buildPassportLoginHandler = (acsURL: string) => {
   return (req: IConfiguredRequest, res: Response, next: NextFunction) => {
+    const handleError = (arg1: any, arg2: any, err: any, status: any) => {
+      logger.error(err.message);
+      logger.error(status);
+      // logger.warn(arg4);
+      return res.redirect("/samlproxy/sp/error");
+    };
     logRelayState(req, logger, "from IDP");
     if (
       ((req.method === "GET" || req.method === "POST") &&
@@ -83,7 +89,7 @@ export const buildPassportLoginHandler = (acsURL: string) => {
       const strategyOptions = req.strategies.get(spIdpKey)?.options;
       assignIn(strategyOptions, params);
       const passport = preparePassport(req.strategies.get(spIdpKey));
-      passport.authenticate("wsfed-saml2", params)(req, res, next);
+      passport.authenticate("wsfed-saml2", params, handleError)(req, res, next);
     } else {
       res.render("error.hbs", {
         request_id: rTracer.id(),

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -5,7 +5,7 @@ import { preparePassport } from "./passport";
 
 import { NextFunction, Response } from "express";
 import assignIn from "lodash.assignin";
-import samlp, { auth } from "samlp";
+import samlp from "samlp";
 import * as url from "url";
 import logger from "../logger";
 import {
@@ -61,12 +61,12 @@ const sufficientLevelOfAssurance = (claims: any) => {
 export const buildPassportLoginHandler = (acsURL: string) => {
   return (req: IConfiguredRequest, res: Response, next: NextFunction) => {
     const authenticateCB = (arg1: any, arg2: any, err: any, status: any) => {
-      if (Object.keys(err).length != 0) {
+      if (err.message) {
         logger.error(err.message);
         logger.error(status);
         return res.redirect("/samlproxy/sp/error");
       } else {
-        // logger.info(arg2); //user obj like below can be deleted 
+        // logger.info(arg2); //user obj like below can be deleted
         /*
   "level": "info",
   "message": {

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -60,44 +60,22 @@ const sufficientLevelOfAssurance = (claims: any) => {
 
 export const buildPassportLoginHandler = (acsURL: string) => {
   return (req: IConfiguredRequest, res: Response, next: NextFunction) => {
-    const authenticateCB = (arg1: any, arg2: any, err: any, status: any) => {
+    const authenticateCallBack = (
+      arg1: any,
+      userInfo: any,
+      err: any,
+      status: any
+    ) => {
       if (err.message) {
         logger.error(err.message);
         logger.error(status);
         return res.redirect("/samlproxy/sp/error");
-      } else {
-        // logger.info(arg2); //user obj like below can be deleted
-        /*
-  "level": "info",
-  "message": {
-    "authnContext": {
-      "authnMethod": "http://idmanagement.gov/ns/assurance/loa/3",
-      "sessionIndex": "_504a0d848a564632aec554ed389011f4"
-    },
-    "claims": {
-      "dateOfBirth": "****-10-30",
-      "email": "va.api.user+idme.003@gmail.com",
-      "firstName": "RALPH",
-      "gender": "male",
-      "idp": "id_me",
-      "lastName": "LE",
-      "level_of_assurance": "3",
-      "middleName": "E",
-      "multifactor": "true",
-      "ssn": "79637****",
-      "uuid": "ccb134182ad14a82b53083e3cb2e****"
-    },
-    "issuer": "api.idmelabs.com",
-    "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
-    "userName": "ccb134182ad14a82b53083e3cb2e****"
-  },
-  "request_id": "a3daddd0-53d6-11ed-****-8bf0d484f72c",
-  "service": "saml-proxy",
-  "time": "2022-10-24T20:01:42.155Z"
-}*/
-        req.user = arg2;
-        next();
       }
+      // userInfo contains the user object returned from the SAML identity provider,
+      // in this case the happy path should simply pass forward the user identity
+      // in the request which be validated later in the execution flow.
+      req.user = userInfo;
+      next();
     };
     logRelayState(req, logger, "from IDP");
     if (
@@ -122,7 +100,7 @@ export const buildPassportLoginHandler = (acsURL: string) => {
       const strategyOptions = req.strategies.get(spIdpKey)?.options;
       assignIn(strategyOptions, params);
       const passport = preparePassport(req.strategies.get(spIdpKey));
-      passport.authenticate("wsfed-saml2", params, authenticateCB)(
+      passport.authenticate("wsfed-saml2", params, authenticateCallBack)(
         req,
         res,
         next

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -5,7 +5,7 @@ import { preparePassport } from "./passport";
 
 import { NextFunction, Response } from "express";
 import assignIn from "lodash.assignin";
-import samlp from "samlp";
+import samlp, { auth } from "samlp";
 import * as url from "url";
 import logger from "../logger";
 import {
@@ -60,11 +60,44 @@ const sufficientLevelOfAssurance = (claims: any) => {
 
 export const buildPassportLoginHandler = (acsURL: string) => {
   return (req: IConfiguredRequest, res: Response, next: NextFunction) => {
-    const handleError = (arg1: any, arg2: any, err: any, status: any) => {
-      logger.error(err.message);
-      logger.error(status);
-      // logger.warn(arg4);
-      return res.redirect("/samlproxy/sp/error");
+    const authenticateCB = (arg1: any, arg2: any, err: any, status: any) => {
+      if (Object.keys(err).length != 0) {
+        logger.error(err.message);
+        logger.error(status);
+        return res.redirect("/samlproxy/sp/error");
+      } else {
+        // logger.info(arg2); //user obj like below can be deleted 
+        /*
+  "level": "info",
+  "message": {
+    "authnContext": {
+      "authnMethod": "http://idmanagement.gov/ns/assurance/loa/3",
+      "sessionIndex": "_504a0d848a564632aec554ed389011f4"
+    },
+    "claims": {
+      "dateOfBirth": "****-10-30",
+      "email": "va.api.user+idme.003@gmail.com",
+      "firstName": "RALPH",
+      "gender": "male",
+      "idp": "id_me",
+      "lastName": "LE",
+      "level_of_assurance": "3",
+      "middleName": "E",
+      "multifactor": "true",
+      "ssn": "79637****",
+      "uuid": "ccb134182ad14a82b53083e3cb2e****"
+    },
+    "issuer": "api.idmelabs.com",
+    "nameIdFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+    "userName": "ccb134182ad14a82b53083e3cb2e****"
+  },
+  "request_id": "a3daddd0-53d6-11ed-****-8bf0d484f72c",
+  "service": "saml-proxy",
+  "time": "2022-10-24T20:01:42.155Z"
+}*/
+        req.user = arg2;
+        next();
+      }
     };
     logRelayState(req, logger, "from IDP");
     if (
@@ -89,7 +122,11 @@ export const buildPassportLoginHandler = (acsURL: string) => {
       const strategyOptions = req.strategies.get(spIdpKey)?.options;
       assignIn(strategyOptions, params);
       const passport = preparePassport(req.strategies.get(spIdpKey));
-      passport.authenticate("wsfed-saml2", params, handleError)(req, res, next);
+      passport.authenticate("wsfed-saml2", params, authenticateCB)(
+        req,
+        res,
+        next
+      );
     } else {
       res.render("error.hbs", {
         request_id: rTracer.id(),


### PR DESCRIPTION
ID.me has completed several certificate rotations without proactive notice to Lighthouse.  Unfortunately the SAML Proxy only loads the active certificate at application start up so once the rotation is performed, the responses from ID.me backed IDP's (ID.me, MHV, and DSLogon) fail.

This change logs when an error occurs due to IDP signing key updates.

to force this change line #31 in app.js to:
     (sKeyCert) => !sKeyCert.active 
Then serve the app & attempt id.me login

Resulting example:

{
  "level": "error",
  "message": "Signature check errors: invalid signature: the signature value Bgm5etw36y/SHhVQFZRnnuAprOoYpUXB4g2xZ+vl1EIHA510r1p+VZqB3OszwE9hAlIspSHclukB8C3zQdh7ohYgYPF62R8udMzXocmpcz495j73wbu3vtRDDDoezZZ+HqwQcZIfMDHPTyjSmy/JhyltGXG0lTuchCL26s37RdTdiwlsaZDvZLk5HH1j+EVVh6FQqM9P9d8R295zPshchPT8ei6Bnl4il+BpjNjJVh6DtRulHGP9Ce4FIirD+kWw0OwPILyAZBP1ux7ZP+BEmhK+xcZ/ViuH+IRzrwx1HEod9cd2eIpNvToAZLBsNiL7NXzgpx6hNlMLywKg8oXa8g== is incorrect",
  "request_id": "1e6f7c60-4e26-11ed-801f-09691c6646af",
  "service": "saml-proxy",
  "time": "2022-10-17T14:16:24.647Z"
}
{
  "level": "error",
  "message": 400,
  "request_id": "1e6f7c60-4e26-11ed-801f-09691c6646af",
  "service": "saml-proxy",
  "time": "2022-10-17T14:16:24.648Z"
}

https://vajira.max.gov/browse/API-20473