### PR TITLE
Toggle styling logging in saml-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ dev-config.json
 ```
 
 `idpAcsUrl`, `idpIssuer`, `idpAudience`, and `idBaseUrl` are all configuration provided by the IDP.
+`styleLogs` is a optional config that can be added to disable all logs related to styling elements like (png, css, woff etc) for local development  (to disable logs set to false)
 
 A functional dev-config file can be found in the [saml-proxy-configs](https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy-configs) repository. Fields with the `FIX_ME` value must be replaced with real values.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ dev-config.json
 ```
 
 `idpAcsUrl`, `idpIssuer`, `idpAudience`, and `idBaseUrl` are all configuration provided by the IDP.
-`styleLogs` is a optional config that can be added to disable all logs related to styling elements like (png, css, woff etc) for local development  (to disable logs set to false)
+`logStyleElementsEnabled` is a optional config that can be added to disable all logs related to styling elements like (png, css, woff etc) for local development  (to disable logs set to false)
 
 A functional dev-config file can be found in the [saml-proxy-configs](https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy-configs) repository. Fields with the `FIX_ME` value must be replaced with real values.
 

--- a/dev-config.base.json
+++ b/dev-config.base.json
@@ -25,7 +25,7 @@
   "redisHost": "127.0.0.1",
   "spIdpSsoBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
   "idpSamlLoginsEnabled": true,
-  "styleLogs": true,
+  "logStyleElementsEnabled": true,
   "idpSamlLogins": 
   [
     {

--- a/dev-config.base.json
+++ b/dev-config.base.json
@@ -25,6 +25,7 @@
   "redisHost": "127.0.0.1",
   "spIdpSsoBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
   "idpSamlLoginsEnabled": true,
+  "styleLogs": true,
   "idpSamlLogins": 
   [
     {

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -106,16 +106,18 @@ export default function configureExpress(
    * Middleware
    */
   app.use(rTracer.expressMiddleware());
-  app.use(
-    morganMiddleware({
-      skip: function (req, res) {
-        return (
-          req.path.startsWith("/samlproxy/idp/bower_components") ||
-          req.path.startsWith("/samlproxy/idp/css")
-        );
-      },
-    })
-  );
+  if (argv.styleLogs == null || argv.styleLogs == true) {
+    app.use(
+      morganMiddleware({
+        skip: function (req, res) {
+          return (
+            req.path.startsWith("/samlproxy/idp/bower_components") ||
+            req.path.startsWith("/samlproxy/idp/css")
+          );
+        },
+      })
+    );
+  }
   app.use(winstonMiddleware);
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(cookieParser());

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -106,7 +106,10 @@ export default function configureExpress(
    * Middleware
    */
   app.use(rTracer.expressMiddleware());
-  if (argv.styleLogs == null || argv.styleLogs == true) {
+  if (
+    argv.logStyleElementsEnabled == null ||
+    argv.logStyleElementsEnabled == true
+  ) {
     app.use(
       morganMiddleware({
         skip: function (req, res) {


### PR DESCRIPTION
Logs in the saml-proxy that involve fetching styling elements, such as .css sheets, are distracting to local development and do not add value.
 
This change allows devs to be able to toggle these on and off using a config option. The default leaves them enabled.

https://vajira.max.gov/browse/API-6846