### PR TITLE
API-25655 ghcr node16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG VERSION
 ARG BUILD_NUMBER
 ARG BUILD_TOOL
 
-FROM vasdvp/lighthouse-node-application-base:node16 as npminstall
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:node16 as npminstall
 
 WORKDIR /home/node
 
@@ -23,7 +23,7 @@ COPY --chown=node:node views/ views/
 COPY --chown=node:node tsconfig.json ./
 RUN ./node_modules/.bin/tsc
 
-FROM vasdvp/lighthouse-node-application-base:node16 as deploy
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:node16 as deploy
 
 WORKDIR /home/node
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,6 +1,6 @@
 # This dockerfile is only used during ci/cd to run regression tests following the ci/cd deploy.
 
-FROM vasdvp/lighthouse-node-application-base:node16 as chromeinstall
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:node16 as chromeinstall
 
 # Build Args
 ARG BUILD_DATE_TIME

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -23,6 +23,8 @@ env:
   parameter-store:
     DOCKER_USERNAME: "/dvp/devops/DOCKER_USERNAME"
     DOCKER_PASSWORD: "/dvp/devops/DOCKER_PASSWORD"
+    GHCR_USERNAME: "/dvp/devops/GHCR_USERNAME"
+    GHCR_TOKEN: "/dvp/devops/GHCR_TOKEN"
   exported-variables:
     - DOCKER_BUILDKIT
 phases:
@@ -45,6 +47,9 @@ phases:
       # Login to Docker Hub prior to pulling base images to avoid rate limiting
       - echo Logging into Docker Hub
       - echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+      # Login to GHCR prior to pulling base images to avoid rate limiting
+        - echo Logging into GHCR
+        - echo "${GHCR_TOKEN}" | docker login ghcr.io -u ${GHCR_USERNAME} --password-stdin
       # Build the image
       - echo Building commit ${TAG}
       - time="${time}\nBuild - $(date +%r) - started"

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -21,8 +21,6 @@ env:
     DOCKER_BUILDKIT: 1
     IMAGE: "saml-proxy"
   parameter-store:
-    DOCKER_USERNAME: "/dvp/devops/DOCKER_USERNAME"
-    DOCKER_PASSWORD: "/dvp/devops/DOCKER_PASSWORD"
     GHCR_USERNAME: "/dvp/devops/GHCR_USERNAME"
     GHCR_TOKEN: "/dvp/devops/GHCR_TOKEN"
   exported-variables:
@@ -44,9 +42,6 @@ phases:
       - printenv
   build:
     commands:
-      # Login to Docker Hub prior to pulling base images to avoid rate limiting
-      - echo Logging into Docker Hub
-      - echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
       # Login to GHCR prior to pulling base images to avoid rate limiting
       - echo Logging into GHCR
       - echo "${GHCR_TOKEN}" | docker login ghcr.io -u ${GHCR_USERNAME} --password-stdin

--- a/cicd/buildspec-ci.yml
+++ b/cicd/buildspec-ci.yml
@@ -48,8 +48,8 @@ phases:
       - echo Logging into Docker Hub
       - echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
       # Login to GHCR prior to pulling base images to avoid rate limiting
-        - echo Logging into GHCR
-        - echo "${GHCR_TOKEN}" | docker login ghcr.io -u ${GHCR_USERNAME} --password-stdin
+      - echo Logging into GHCR
+      - echo "${GHCR_TOKEN}" | docker login ghcr.io -u ${GHCR_USERNAME} --password-stdin
       # Build the image
       - echo Building commit ${TAG}
       - time="${time}\nBuild - $(date +%r) - started"

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -37,8 +37,6 @@ env:
     IMAGE: "saml-proxy"
   parameter-store:
     # For pulling docker images
-    DOCKER_USERNAME: "/dvp/devops/DOCKER_USERNAME"
-    DOCKER_PASSWORD: "/dvp/devops/DOCKER_PASSWORD"
     GHCR_USERNAME: "/dvp/devops/GHCR_USERNAME"
     GHCR_TOKEN: "/dvp/devops/GHCR_TOKEN"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
@@ -110,8 +108,6 @@ phases:
             fi
             echo Logging into ECR
             make login
-            echo Logging into Docker Hub
-            echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
             echo Logging into GHCR
             echo "${GHCR_TOKEN}" | docker login ghcr.io -u ${GHCR_USERNAME} --password-stdin
             echo Running regression tests.

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -39,6 +39,8 @@ env:
     # For pulling docker images
     DOCKER_USERNAME: "/dvp/devops/DOCKER_USERNAME"
     DOCKER_PASSWORD: "/dvp/devops/DOCKER_PASSWORD"
+    GHCR_USERNAME: "/dvp/devops/GHCR_USERNAME"
+    GHCR_TOKEN: "/dvp/devops/GHCR_TOKEN"
     # SLACK_WEBHOOK should be a webhook that posts to the Slack channel you want notifications to go to
     SLACK_WEBHOOK: "/dvp/devops/codebuild_slack_webhook_lighthouse"
     # Values for regression tests
@@ -110,6 +112,8 @@ phases:
             make login
             echo Logging into Docker Hub
             echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+            echo Logging into GHCR
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u ${GHCR_USERNAME} --password-stdin
             echo Running regression tests.
             make regression \
               TAG=${DEPLOY_TAG} \

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -11,7 +11,6 @@ import { accessiblePhoneNumber } from "../utils";
 
 jest.mock("../logger");
 jest.mock("passport-wsfed-saml2");
-// @ts-ignore
 import { samlp } from "passport-wsfed-saml2";
 
 describe("getHashCode, getSessionIndex", () => {
@@ -69,9 +68,9 @@ describe("getHashCode, getSessionIndex", () => {
 });
 
 describe("parseSamlRequest", () => {
-  let mockResponse: any;
-  let mockRequest: any;
-  let mockNext: any;
+  let mockResponse;
+  let mockRequest;
+  let mockNext;
   beforeEach(() => {
     mockRequest = {
       query: {},
@@ -117,9 +116,9 @@ describe("parseSamlRequest", () => {
 });
 
 describe("samlLogin", () => {
-  let mockResponse: any;
-  let mockRequest: any;
-  let mockNext: any;
+  let mockResponse;
+  let mockRequest;
+  let mockNext;
 
   const spOptionsJustIdMe = {
     id_me: {
@@ -197,7 +196,7 @@ describe("samlLogin", () => {
         options: spOptionsJustIdMe,
       },
       authnRequest: {},
-      get: (param: any) => {
+      get: (param) => {
         return param;
       },
     };
@@ -278,10 +277,10 @@ describe("samlLogin", () => {
     });
 
   const promise2check = (
-    expected_template: any,
-    expected_authoptions: any,
-    template: any,
-    auth_options: any
+    expected_template,
+    expected_authoptions,
+    template,
+    auth_options
   ) => {
     return new Promise((resolve, reject) => {
       try {
@@ -300,7 +299,7 @@ describe("samlLogin", () => {
       relayState: "%2Foauth2%2FtheRelayState",
     };
 
-    mockResponse.render = function render(template: any, authOptions: any) {
+    mockResponse.render = function render(template, authOptions) {
       return promise2check(
         "layout",
         expected_authoptions,
@@ -328,7 +327,7 @@ describe("samlLogin", () => {
       relayState: "theRelayState",
     };
 
-    mockResponse.render = function render(template: any, authOptions: any) {
+    mockResponse.render = function render(template, authOptions) {
       return promise2check(
         "login_selection",
         expected_authoptions,
@@ -363,7 +362,7 @@ describe("samlLogin", () => {
 
     mockRequest.sps.options = spOptionsJustwithLoginGov;
 
-    mockResponse.render = function render(template: any, authOptions: any) {
+    mockResponse.render = function render(template, authOptions) {
       return promise2check(
         "layout",
         expected_authoptions_login_gov_enabled,
@@ -413,7 +412,7 @@ describe("samlLogin", () => {
   });
 
   it("Happy Path, no authnRequest", async () => {
-    mockResponse.render = function render(template: any, authOptions: any) {
+    mockResponse.render = function render(template, authOptions) {
       return promise2check(
         "layout",
         expected_authoptions_verify,
@@ -439,7 +438,7 @@ describe("samlLogin", () => {
   });
 
   it("Happy Path, no authnRequest, login.gov failure_to_proof", async () => {
-    mockResponse.render = function render(template: any, authOptions: any) {
+    mockResponse.render = function render(template, authOptions) {
       return promise2check(
         "layout",
 

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -11,6 +11,7 @@ import { accessiblePhoneNumber } from "../utils";
 
 jest.mock("../logger");
 jest.mock("passport-wsfed-saml2");
+// @ts-ignore
 import { samlp } from "passport-wsfed-saml2";
 
 describe("getHashCode, getSessionIndex", () => {
@@ -68,9 +69,9 @@ describe("getHashCode, getSessionIndex", () => {
 });
 
 describe("parseSamlRequest", () => {
-  let mockResponse;
-  let mockRequest;
-  let mockNext;
+  let mockResponse: any;
+  let mockRequest: any;
+  let mockNext: any;
   beforeEach(() => {
     mockRequest = {
       query: {},
@@ -116,9 +117,9 @@ describe("parseSamlRequest", () => {
 });
 
 describe("samlLogin", () => {
-  let mockResponse;
-  let mockRequest;
-  let mockNext;
+  let mockResponse: any;
+  let mockRequest: any;
+  let mockNext: any;
 
   const spOptionsJustIdMe = {
     id_me: {
@@ -196,7 +197,7 @@ describe("samlLogin", () => {
         options: spOptionsJustIdMe,
       },
       authnRequest: {},
-      get: (param) => {
+      get: (param: any) => {
         return param;
       },
     };
@@ -277,10 +278,10 @@ describe("samlLogin", () => {
     });
 
   const promise2check = (
-    expected_template,
-    expected_authoptions,
-    template,
-    auth_options
+    expected_template: any,
+    expected_authoptions: any,
+    template: any,
+    auth_options: any
   ) => {
     return new Promise((resolve, reject) => {
       try {
@@ -299,7 +300,7 @@ describe("samlLogin", () => {
       relayState: "%2Foauth2%2FtheRelayState",
     };
 
-    mockResponse.render = function render(template, authOptions) {
+    mockResponse.render = function render(template: any, authOptions: any) {
       return promise2check(
         "layout",
         expected_authoptions,
@@ -327,7 +328,7 @@ describe("samlLogin", () => {
       relayState: "theRelayState",
     };
 
-    mockResponse.render = function render(template, authOptions) {
+    mockResponse.render = function render(template: any, authOptions: any) {
       return promise2check(
         "login_selection",
         expected_authoptions,
@@ -362,7 +363,7 @@ describe("samlLogin", () => {
 
     mockRequest.sps.options = spOptionsJustwithLoginGov;
 
-    mockResponse.render = function render(template, authOptions) {
+    mockResponse.render = function render(template: any, authOptions: any) {
       return promise2check(
         "layout",
         expected_authoptions_login_gov_enabled,
@@ -412,7 +413,7 @@ describe("samlLogin", () => {
   });
 
   it("Happy Path, no authnRequest", async () => {
-    mockResponse.render = function render(template, authOptions) {
+    mockResponse.render = function render(template: any, authOptions: any) {
       return promise2check(
         "layout",
         expected_authoptions_verify,
@@ -438,7 +439,7 @@ describe("samlLogin", () => {
   });
 
   it("Happy Path, no authnRequest, login.gov failure_to_proof", async () => {
-    mockResponse.render = function render(template, authOptions) {
+    mockResponse.render = function render(template: any, authOptions: any) {
       return promise2check(
         "layout",
 


### PR DESCRIPTION
targets ghcr and updates the docker login credentials. 
requires deveps support to add ghcr token, using personal token temporarily to unblock.
https://github.com/department-of-veterans-affairs/lighthouse-devops-support/issues/2425