### PR TITLE
API-13875-fix-modify-regression-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ regression:
 		--user-password=$(USER_PASSWORD) \
 		--valid-user=$(VALID_USER_EMAIL) \
 		--icn-error-user=$(ICN_ERROR_USER_EMAIL)
-		--timeout=$(TIMEOUT)
+		--regression-test-timeout=$(REGRESSION_TEST_TIMEOUT)
 
 ## pull: 	Pull an image to ECR
 .PHONY: pull

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ regression:
 		--user-password=$(USER_PASSWORD) \
 		--valid-user=$(VALID_USER_EMAIL) \
 		--icn-error-user=$(ICN_ERROR_USER_EMAIL)
+		--timeout=$(TIMEOUT)
 
 ## pull: 	Pull an image to ECR
 .PHONY: pull

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -49,7 +49,7 @@ env:
     USER_PASSWORD: "/dvp/common/ecs-saml-proxy/codebuild/user_password"
     VALID_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/valid_user_email"
     ICN_ERROR_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/icn_error_user_email"
-    TIMEOUT: "/dvp/common/ecs-saml-proxy/codebuild/regression_test_timeout"
+    REGRESSION_TEST_TIMEOUT: "/dvp/common/ecs-saml-proxy/codebuild/regression_test_timeout"
 phases:
   install:
     commands:
@@ -122,7 +122,7 @@ phases:
               USER_PASSWORD=${USER_PASSWORD} \
               VALID_USER_EMAIL=${VALID_USER_EMAIL} \
               ICN_ERROR_USER_EMAIL=${ICN_ERROR_USER_EMAIL}
-              TIMEOUT=${TIMEOUT}
+              REGRESSION_TEST_TIMEOUT=${REGRESSION_TEST_TIMEOUT}
             if [[ $? -gt 0 ]]; then
               slackpost.sh -t warning "Some regression tests failed."
             fi

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -49,6 +49,7 @@ env:
     USER_PASSWORD: "/dvp/common/ecs-saml-proxy/codebuild/user_password"
     VALID_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/valid_user_email"
     ICN_ERROR_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/icn_error_user_email"
+    TIMEOUT: "/dvp/common/ecs-saml-proxy/codebuild/regression_test_timeout"
 phases:
   install:
     commands:

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -121,6 +121,7 @@ phases:
               USER_PASSWORD=${USER_PASSWORD} \
               VALID_USER_EMAIL=${VALID_USER_EMAIL} \
               ICN_ERROR_USER_EMAIL=${ICN_ERROR_USER_EMAIL}
+              TIMEOUT=${TIMEOUT}
             if [[ $? -gt 0 ]]; then
               slackpost.sh -t warning "Some regression tests failed."
             fi

--- a/test/regression_tests/saml-proxy-regression.test.js
+++ b/test/regression_tests/saml-proxy-regression.test.js
@@ -162,7 +162,7 @@ describe("Regression tests", () => {
     await page.waitForSelector(".usa-alert-error");
 
     await isSensitiveError(page);
-  });
+  }, process.env.TIMEOUT);
 });
 
 const requestToken = async (page) => {

--- a/test/regression_tests/saml-proxy-regression.test.js
+++ b/test/regression_tests/saml-proxy-regression.test.js
@@ -23,9 +23,10 @@ const redirect_uri = "https://app/after-auth";
 const user_password = process.env.USER_PASSWORD;
 const valid_user = process.env.VALID_USER_EMAIL;
 const icn_error_user = process.env.ICN_ERROR_USER_EMAIL;
+const regression_test_timeout = process.env.REGRESSION_TEST_TIMEOUT ? process.env.REGRESSION_TEST_TIMEOUT : 70000;
 
 describe("Regression tests", () => {
-  jest.setTimeout(70000);
+  jest.setTimeout(regression_test_timeout);
   let browser;
   beforeEach(async () => {
     browser = await puppeteer.launch(launchArgs);
@@ -162,7 +163,7 @@ describe("Regression tests", () => {
     await page.waitForSelector(".usa-alert-error");
 
     await isSensitiveError(page);
-  }, process.env.TIMEOUT);
+  });
 });
 
 const requestToken = async (page) => {


### PR DESCRIPTION
- Added TIMEOUT env variable, so we can easily adjust regression test timeout within param store. 
- Added TIMEOUT to the "modify" regression test, so we can increase as needed.