### PR TITLE
Api 25634 npm fail build warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ WORKDIR /home/node
 RUN git config --global url."https://".insteadOf git://
 COPY --chown=node:node package.json package.json
 COPY --chown=node:node package-lock.json package-lock.json
-RUN npm install
+COPY --chown=node:node ./install.sh install.sh
+RUN ./install.sh
 
 FROM npminstall as tscbuild
 

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # Team Pivot!
 
-if npm install 2>&1 | grep -q "WARN"; then
+output=$(npm install --loglevel=error 2>&1)
+
+if npm "$output" | grep -q "WARN"; then
     echo ERROR: npm WARN detected
     exit 1
 fi
+
+echo "No NPM warnings detected."
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Team Pivot!
+
+if npm install 2>&1 | grep -q "WARN"; then
+    echo ERROR: npm WARN detected
+    exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 # Team Pivot!
 
-output=$(npm install --loglevel=error 2>&1)
-
-if npm "$output" | grep -q "WARN"; then
+if npm install 2>&1 | grep -q "WARN"; then
     echo ERROR: npm WARN detected
     exit 1
 fi


### PR DESCRIPTION
This PR is to add a script similar to the oauth-proxy to fail the npm install if there are warnings that exist. There are warnings that exist in this repo so this will be a draft PR until those warnings are addressed.

Link to JIRA: https://vajira.max.gov/browse/API-25634