### PR TITLE
API-000 remove participant

### DIFF
--- a/src/routes/handlers.js
+++ b/src/routes/handlers.js
@@ -163,19 +163,6 @@ export const parseSamlRequest = function (req, res, next) {
   });
 };
 
-export const getParticipant = (req) => {
-  const participant = {
-    serviceProviderId: req.idp.options.serviceProviderId,
-    sessionIndex: getSamlId(req),
-    serviceProviderLogoutURL: req.idp.options.sloUrl,
-  };
-  if (req.user) {
-    participant.nameId = req.user.userName;
-    participant.nameIdFormat = req.user.nameIdFormat;
-  }
-  return participant;
-};
-
 const processAcs = (acsUrl, cache, cacheEnabled) => [
   buildPassportLoginHandler(acsUrl),
   testLevelOfAssuranceOrRedirect,

--- a/src/routes/handlers.test.ts
+++ b/src/routes/handlers.test.ts
@@ -3,7 +3,6 @@ import {
   getHashCode,
   samlLogin,
   parseSamlRequest,
-  getParticipant,
   handleError,
 } from "./handlers.js";
 import { accessiblePhoneNumber, getSamlId } from "../utils";
@@ -47,15 +46,6 @@ describe("getHashCode, getSessionIndex", () => {
   });
   test("getSamlId happy", () => {
     expect(getSamlId(mockReq)).toEqual("1666277972");
-  });
-  test("getParticipant", () => {
-    expect(getParticipant(mockReq)).toEqual({
-      serviceProviderId: "serviceProviderId1",
-      sessionIndex: "1666277972",
-      serviceProviderLogoutURL: "sloUrl1",
-      nameId: "uname1",
-      nameIdFormat: "nameIdFormat1",
-    });
   });
   test("handleError", () => {
     handleError(mockReq, mockRes);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -14,7 +14,6 @@ import {
   logger,
 } from "../logger";
 import addRoutes from "./routes";
-import { getParticipant } from "./handlers";
 
 import promBundle from "express-prom-bundle";
 import * as Sentry from "@sentry/node";
@@ -161,7 +160,6 @@ export default function configureExpress(
     req.vsoClient = vsoClient;
     req.sps = { options: spOptions };
     req.idp = { options: idpOptions };
-    req.participant = getParticipant(req);
     req.requestAcsUrl = argv.spAcsUrl;
     next();
   });


### PR DESCRIPTION
- Removes code that was causing a SAML ID lookup failure when metadata endpoint called.