### PR TITLE
API-28014 saml proxy docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ EXPOSE 7000 7000
 HEALTHCHECK --interval=1m --timeout=4s --start-period=30s \
   CMD curl -f http://localhost:7000/samlproxy/idp/metadata || exit 1
 
-USER node
-
 ENTRYPOINT ["/usr/local/bin/tini", "--"]
 CMD ["node", "build/app.js", "--config", "/etc/saml-proxy/config.json"]
 
@@ -58,8 +56,6 @@ COPY --chown=lhuser:lhuser views/ views/
 COPY --chown=lhuser:lhuser tsconfig.json ./
 COPY --chown=lhuser:lhuser .eslint* ./
 COPY --chown=lhuser:lhuser tsconfig.json ./
-
-USER node
 
 # Static Labels
 LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,38 +4,38 @@ ARG VERSION
 ARG BUILD_NUMBER
 ARG BUILD_TOOL
 
-FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:node16 as npminstall
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:v2-node16 as npminstall
 
-WORKDIR /home/node
+WORKDIR /home/lhuser
 
 RUN git config --global url."https://".insteadOf git://
-COPY --chown=node:node package.json package.json
-COPY --chown=node:node package-lock.json package-lock.json
+COPY --chown=lhuser:lhuser package.json package.json
+COPY --chown=lhuser:lhuser package-lock.json package-lock.json
 RUN npm install
 
 FROM npminstall as tscbuild
 
-COPY --chown=node:node bin/ bin/
-COPY --chown=node:node src/ src/
-COPY --chown=node:node public/ public/
-COPY --chown=node:node styles/ styles/
-COPY --chown=node:node views/ views/
-COPY --chown=node:node tsconfig.json ./
+COPY --chown=lhuser:lhuser bin/ bin/
+COPY --chown=lhuser:lhuser src/ src/
+COPY --chown=lhuser:lhuser public/ public/
+COPY --chown=lhuser:lhuser styles/ styles/
+COPY --chown=lhuser:lhuser views/ views/
+COPY --chown=lhuser:lhuser tsconfig.json ./
 RUN ./node_modules/.bin/tsc
 
-FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:node16 as deploy
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:v2-node16 as deploy
 
-WORKDIR /home/node
+WORKDIR /home/lhuser
 
-COPY --chown=node:node *.pem ./
-COPY --chown=node:node *.key ./
+COPY --chown=lhuser:lhuser *.pem ./
+COPY --chown=lhuser:lhuser *.key ./
 
-COPY --from=tscbuild --chown=node:node /home/node/bin/ ./bin/
-COPY --from=tscbuild --chown=node:node /home/node/public/ ./public/
-COPY --from=tscbuild --chown=node:node /home/node/styles/ ./styles/
-COPY --from=tscbuild --chown=node:node /home/node/views/ ./views/
-COPY --from=tscbuild --chown=node:node /home/node/node_modules/ ./node_modules/
-COPY --from=tscbuild --chown=node:node /home/node/build/ ./build/
+COPY --from=tscbuild --chown=lhuser:lhuser /home/lhuser/bin/ ./bin/
+COPY --from=tscbuild --chown=lhuser:lhuser /home/lhuser/public/ ./public/
+COPY --from=tscbuild --chown=lhuser:lhuser /home/lhuser/styles/ ./styles/
+COPY --from=tscbuild --chown=lhuser:lhuser /home/lhuser/views/ ./views/
+COPY --from=tscbuild --chown=lhuser:lhuser /home/lhuser/node_modules/ ./node_modules/
+COPY --from=tscbuild --chown=lhuser:lhuser /home/lhuser/build/ ./build/
 
 EXPOSE 7000 7000
 
@@ -49,15 +49,15 @@ CMD ["node", "build/app.js", "--config", "/etc/saml-proxy/config.json"]
 
 FROM npminstall as testandlint
 
-COPY --chown=node:node bin/ bin/
-COPY --chown=node:node src/ src/
-COPY --chown=node:node test/ test/
-COPY --chown=node:node public/ public/
-COPY --chown=node:node styles/ styles/
-COPY --chown=node:node views/ views/
-COPY --chown=node:node tsconfig.json ./
-COPY --chown=node:node .eslint* ./
-COPY --chown=node:node tsconfig.json ./
+COPY --chown=lhuser:lhuser bin/ bin/
+COPY --chown=lhuser:lhuser src/ src/
+COPY --chown=lhuser:lhuser test/ test/
+COPY --chown=lhuser:lhuser public/ public/
+COPY --chown=lhuser:lhuser styles/ styles/
+COPY --chown=lhuser:lhuser views/ views/
+COPY --chown=lhuser:lhuser tsconfig.json ./
+COPY --chown=lhuser:lhuser .eslint* ./
+COPY --chown=lhuser:lhuser tsconfig.json ./
 
 USER node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,20 @@ COPY --chown=lhuser:lhuser tsconfig.json ./
 COPY --chown=lhuser:lhuser .eslint* ./
 COPY --chown=lhuser:lhuser tsconfig.json ./
 
+# The following section is temporary until a followup fix on the ci
+USER root
+RUN chown -R lhuser:lhuser /home/node/
+USER lhuser
+COPY --chown=lhuser:lhuser bin/ /home/node/bin/
+COPY --chown=lhuser:lhuser src/ /home/node/src/
+COPY --chown=lhuser:lhuser test/ /home/node/test/
+COPY --chown=lhuser:lhuser public/ /home/node/public/
+COPY --chown=lhuser:lhuser styles/ /home/node/styles/
+COPY --chown=lhuser:lhuser views/ /home/node/views/
+COPY --chown=lhuser:lhuser tsconfig.json /home/node/
+COPY --chown=lhuser:lhuser .eslint* /home/node/
+COPY --chown=lhuser:lhuser tsconfig.json /home/node/
+
 # Static Labels
 LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \
       org.opencontainers.image.url="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/tree/master/Dockerfile" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ COPY --chown=lhuser:lhuser views/ /home/node/views/
 COPY --chown=lhuser:lhuser tsconfig.json /home/node/
 COPY --chown=lhuser:lhuser .eslint* /home/node/
 COPY --chown=lhuser:lhuser tsconfig.json /home/node/
+COPY --chown=lhuser:lhuser --from=npminstall package*.json /home/node/
+COPY --chown=lhuser:lhuser --from=npminstall node_modules/ /home/node/node_modules/
 
 # Static Labels
 LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,19 +59,9 @@ COPY --chown=lhuser:lhuser tsconfig.json ./
 
 # The following section is temporary until a followup fix on the ci
 USER root
+RUN cp -r /home/lhuser/. /home/node/
 RUN chown -R lhuser:lhuser /home/node/
 USER lhuser
-COPY --chown=lhuser:lhuser bin/ /home/node/bin/
-COPY --chown=lhuser:lhuser src/ /home/node/src/
-COPY --chown=lhuser:lhuser test/ /home/node/test/
-COPY --chown=lhuser:lhuser public/ /home/node/public/
-COPY --chown=lhuser:lhuser styles/ /home/node/styles/
-COPY --chown=lhuser:lhuser views/ /home/node/views/
-COPY --chown=lhuser:lhuser tsconfig.json /home/node/
-COPY --chown=lhuser:lhuser .eslint* /home/node/
-COPY --chown=lhuser:lhuser tsconfig.json /home/node/
-COPY --chown=lhuser:lhuser --from=npminstall package*.json /home/node/
-COPY --chown=lhuser:lhuser --from=npminstall node_modules/ /home/node/node_modules/
 
 # Static Labels
 LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \


### PR DESCRIPTION
Addresses [API-28863](https://jira.devops.va.gov/browse/API-28863)
 - Updates the base image used to build the docker image for saml-proxy