### PR TITLE
API-28863 test and lint, ci-cd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ build/saml_tests:
 lint:
 	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy)
 	docker run --rm --entrypoint='' \
-		-w "/home/node" \
 		$(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
 		npm run-script lint
 
@@ -99,7 +98,6 @@ lint:
 test:
 	@:$(call check_defined, IMAGE, IMAGE variable should be saml-proxy)
 	docker run --rm --entrypoint='' \
-		-w "/home/node" \
 		$(REPOSITORY)/$(NAMESPACE)/$(IMAGE):$(TAG) \
 		npm run test:ci
 


### PR DESCRIPTION
Addresses [API-28863](https://jira.devops.va.gov/browse/API-28863)
 - Remove workspace override during ci/cd of lint and unit tests
   - This will allow for an image change when transitioning to new base image