### PR TITLE
API-28863 ci cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,12 +57,6 @@ COPY --chown=lhuser:lhuser tsconfig.json ./
 COPY --chown=lhuser:lhuser .eslint* ./
 COPY --chown=lhuser:lhuser tsconfig.json ./
 
-# The following section is temporary until a followup fix on the ci
-USER root
-RUN cp -r /home/lhuser/. /home/node/
-RUN chown -R lhuser:lhuser /home/node/
-USER lhuser
-
 # Static Labels
 LABEL org.opencontainers.image.authors="leeroy-jenkles@va.gov" \
       org.opencontainers.image.url="https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/tree/master/Dockerfile" \


### PR DESCRIPTION
Addresses [API-28863](https://jira.devops.va.gov/browse/API-28863)
 - Cleans up section needed to work with previous ci setup.
 - The PR most proceed https://github.com/department-of-veterans-affairs/lighthouse-saml-proxy/pull/462