### PR TITLE
API-30528 Node18 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ ARG VERSION
 ARG BUILD_NUMBER
 ARG BUILD_TOOL
 
-FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:v2-node16 as npminstall
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:v2-node18 as npminstall
+
+# Downgrade of npm needed to run npm install for saml-proxy
+USER root 
+RUN npm install -g npm@7.15.1
+USER lhuser
 
 WORKDIR /home/lhuser
 
-RUN git config --global url."https://".insteadOf git://
 COPY --chown=lhuser:lhuser package.json package.json
 COPY --chown=lhuser:lhuser package-lock.json package-lock.json
 RUN npm install
@@ -23,7 +27,7 @@ COPY --chown=lhuser:lhuser views/ views/
 COPY --chown=lhuser:lhuser tsconfig.json ./
 RUN ./node_modules/.bin/tsc
 
-FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:v2-node16 as deploy
+FROM ghcr.io/department-of-veterans-affairs/health-apis-docker-octopus/lighthouse-node-application-base:v2-node18 as deploy
 
 WORKDIR /home/lhuser
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -22,13 +22,13 @@ RUN yum -y install https://dl.google.com/linux/direct/google-chrome-stable_curre
 
 FROM devchromebase as devnodebase
 
-# #
-# # NodeJS 18.x
-# #
-# RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
-# RUN retry yum install -y -q nodejs gcc-c++ make python3 git \
-#   && retry yum install --assumeyes --quiet tar gzip xz zip unzip
-# RUN npm install -g npm@7.15.1
+#
+# NodeJS 18.x
+#
+RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
+RUN retry yum install -y -q nodejs gcc-c++ make python3 git \
+  && retry yum install --assumeyes --quiet tar gzip xz zip unzip
+RUN npm install -g npm@7.15.1
 
 FROM devnodebase
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -20,14 +20,14 @@ LABEL org.opencontainers.image.authors="Pivot!" \
 # Install chrome dependencies
 RUN yum -y install https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
 
+FROM ghcr.io/department-of-veterans-affairs/lighthouse-node-build:v2-node18 as nodebuild
+
 FROM devchromebase as devnodebase
 
 #
 # NodeJS 18.x
 #
-RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
-RUN retry yum install -y -q nodejs gcc-c++ make python3 git \
-  && retry yum install --assumeyes --quiet tar gzip xz zip unzip
+COPY --from=nodebuild /usr/local/ /usr/local/
 RUN npm install -g npm@7.15.1
 
 FROM devnodebase

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -22,13 +22,13 @@ RUN yum -y install https://dl.google.com/linux/direct/google-chrome-stable_curre
 
 FROM devchromebase as devnodebase
 
-#
-# NodeJS 16.x
-#
-RUN curl -sL https://rpm.nodesource.com/setup_16.x | bash -
-RUN retry yum install -y -q nodejs gcc-c++ make python3 git \
-  && retry yum install --assumeyes --quiet tar gzip xz zip unzip
-RUN npm install -g npm@7.15.1
+# #
+# # NodeJS 18.x
+# #
+# RUN curl -sL https://rpm.nodesource.com/setup_18.x | bash -
+# RUN retry yum install -y -q nodejs gcc-c++ make python3 git \
+#   && retry yum install --assumeyes --quiet tar gzip xz zip unzip
+# RUN npm install -g npm@7.15.1
 
 FROM devnodebase
 


### PR DESCRIPTION
This PR is to upgrade the saml-proxy to use node18 instead of node16. 