### PR TITLE
API-29508 Remove Header x-powered-by

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -76,6 +76,7 @@ function runServer(argv) {
     .then(handleMetadata(argv))
     .then(() => {
       const app = express();
+      app.disable("x-powered-by");
       const httpServer = http.createServer(app);
       const spConfigs = { id_me: new SPConfig(argv) };
       strategies.set("id_me", createPassportStrategy(spConfigs.id_me));


### PR DESCRIPTION
Description:
This PR removes the header "x-powered-by" from HTTP responses. This was brought to team Pivot! attention during a WASA scan (Low risk). 

The reason the WASA team wants this header removed, is that it discloses sensitive information about itself and its infrastructure.

Related Issue(s):
https://jira.devops.va.gov/browse/API-29508