### PR TITLE
API-34013 ICN error regression test fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,8 @@ regression:
 		--authorization-url=$(AUTHORIZATION_URL) \
 		--user-password=$(USER_PASSWORD) \
 		--valid-user=$(VALID_USER_EMAIL) \
-		--icn-error-user=$(ICN_ERROR_USER_EMAIL)
+		--icn-error-user=$(ICN_ERROR_USER_EMAIL) \
+		--icn-error-password=$(ICN_ERROR_PASSWORD)
 		--regression-test-timeout=$(REGRESSION_TEST_TIMEOUT)
 
 ## pull: 	Pull an image to ECR

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ regression:
 		--user-password=$(USER_PASSWORD) \
 		--valid-user=$(VALID_USER_EMAIL) \
 		--icn-error-user=$(ICN_ERROR_USER_EMAIL) \
-		--icn-error-password=$(ICN_ERROR_PASSWORD)
+		--icn-error-password=$(ICN_ERROR_PASSWORD) \
 		--regression-test-timeout=$(REGRESSION_TEST_TIMEOUT)
 
 ## pull: 	Pull an image to ECR

--- a/cicd/buildspec-deploy.yml
+++ b/cicd/buildspec-deploy.yml
@@ -49,6 +49,7 @@ env:
     USER_PASSWORD: "/dvp/common/ecs-saml-proxy/codebuild/user_password"
     VALID_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/valid_user_email"
     ICN_ERROR_USER_EMAIL: "/dvp/common/ecs-saml-proxy/codebuild/icn_error_user_email"
+    ICN_ERROR_PASSWORD: "/dvp/common/ecs-saml-proxy/codebuild/icn_error_password"
     REGRESSION_TEST_TIMEOUT: "/dvp/common/ecs-saml-proxy/codebuild/regression_test_timeout"
 phases:
   install:
@@ -121,7 +122,8 @@ phases:
               AUTHORIZATION_URL=${AUTHORIZATION_URL} \
               USER_PASSWORD=${USER_PASSWORD} \
               VALID_USER_EMAIL=${VALID_USER_EMAIL} \
-              ICN_ERROR_USER_EMAIL=${ICN_ERROR_USER_EMAIL}
+              ICN_ERROR_USER_EMAIL=${ICN_ERROR_USER_EMAIL} \
+              ICN_ERROR_PASSWORD=${ICN_ERROR_PASSWORD} \
               REGRESSION_TEST_TIMEOUT=${REGRESSION_TEST_TIMEOUT}
             if [[ $? -gt 0 ]]; then
               slackpost.sh -t warning "Some regression tests failed."

--- a/test/regression_tests/entrypoint_test.sh
+++ b/test/regression_tests/entrypoint_test.sh
@@ -13,6 +13,7 @@ docker run \
   --authorization-url=$AUTHORIZATION_URL \
   --user-password=$USER_PASSWORD \
   --valid-user=$VALID_USER_EMAIL \
+  --icn-error-password=$ICN_ERROR_PASSWORD \
   --icn-error-user=$ICN_ERROR_USER_EMAIL
 
 EOF
@@ -44,6 +45,8 @@ case $i in
       export VALID_USER_EMAIL="${i#*=}"; shift ;;
     --icn-error-user=*)
       export ICN_ERROR_USER_EMAIL="${i#*=}"; shift ;;
+    --icn-error-password=*)
+      export ICN_ERROR_PASSWORD="${i#*=}"; shift ;;
 esac
 done
 

--- a/test/regression_tests/saml-proxy-regression.test.js
+++ b/test/regression_tests/saml-proxy-regression.test.js
@@ -23,6 +23,7 @@ const redirect_uri = "https://app/after-auth";
 const user_password = process.env.USER_PASSWORD;
 const valid_user = process.env.VALID_USER_EMAIL;
 const icn_error_user = process.env.ICN_ERROR_USER_EMAIL;
+const icn_error_password = process.env.ICN_ERROR_PASSWORD
 const regression_test_timeout = process.env.REGRESSION_TEST_TIMEOUT
   ? Number(process.env.REGRESSION_TEST_TIMEOUT)
   : 70000;
@@ -50,7 +51,7 @@ describe("Regression tests", () => {
     const page = await browser.newPage();
     await requestToken(page);
 
-    await login(page, icn_error_user, user_password);
+    await login(page, icn_error_user, icn_error_password);
 
     await page.waitForRequest((request) => {
       return request.url().includes("/samlproxy/sp/saml/sso");
@@ -134,7 +135,7 @@ describe("Regression tests", () => {
   test("modify", async () => {
     const page = await browser.newPage();
     await requestToken(page);
-    await authentication(page, valid_user, true);
+    await authentication(page, valid_user, user_password, true);
 
     page.on("request", async (request) => {
       if (
@@ -186,7 +187,7 @@ const requestToken = async (page) => {
 };
 
 const login = async (page, useremail, password, get_code = false) => {
-  await authentication(page, useremail);
+  await authentication(page, useremail, password);
 
   let code;
   if (get_code) {
@@ -200,11 +201,11 @@ const login = async (page, useremail, password, get_code = false) => {
   return code;
 };
 
-const authentication = async (page, email = valid_user, intercept = false) => {
+const authentication = async (page, email = valid_user, password = user_password, intercept = false) => {
   await page.$eval(".idme-signin", (elem) => elem.click());
   await page.waitForSelector("#user_email");
   await page.type("#user_email", email);
-  await page.type("#user_password", user_password);
+  await page.type("#user_password", password);
   await page.$eval('[name="commit"]', (elem) => elem.click());
   await page.waitForSelector(".phone");
   await page.$eval("button.btn-primary", (elem) => elem.click());


### PR DESCRIPTION
This PR is to temporarily alter the icn_error regression test to add a separate env password var so that it can use the old account's password instead of relying on the new id.me accounts. The reason for this change is because there is no valid user in the new id.me test accounts for the icn_error test to use.

Link to Jira: https://jira.devops.va.gov/browse/API-34013