### PR TITLE
API-34013 Skipping Regression Tests

### DIFF
--- a/test/regression_tests/saml-proxy-regression.test.js
+++ b/test/regression_tests/saml-proxy-regression.test.js
@@ -46,7 +46,7 @@ describe("Regression tests", () => {
     expect(code).not.toBeNull();
   });
 
-  test("ICN Error", async () => {
+  test.skip("ICN Error", async () => {
     const page = await browser.newPage();
     await requestToken(page);
 
@@ -131,7 +131,7 @@ describe("Regression tests", () => {
     await isError(page, "Error", "Route Not Found");
   });
 
-  test("modify", async () => {
+  test.skip("modify", async () => {
     const page = await browser.newPage();
     await requestToken(page);
     await authentication(page, valid_user, true);


### PR DESCRIPTION
This PR is to skip the icn_error and modify regression tests so that it doesn't run into problems when switched over to the new id.me test accounts.


Link to Jira: https://jira.devops.va.gov/browse/API-34013