### PR TITLE
API-41014 Fraud Identity Theft

### DIFF
--- a/dev-config.base.json
+++ b/dev-config.base.json
@@ -25,12 +25,11 @@
   "sessionSecret": "fake-session-secret",
   "cacheEnabled": true,
   "redisPort": "6379",
-  "fraudBlockEnabled": true,
   "redisHost": "127.0.0.1",
   "spIdpSsoBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
   "idpSamlLoginsEnabled": true,
   "logStyleElementsEnabled": true,
-  "idpSamlLogins":
+  "idpSamlLogins": 
   [
     {
       "category": "example2SamlIdp",

--- a/dev-config.base.json
+++ b/dev-config.base.json
@@ -25,11 +25,12 @@
   "sessionSecret": "fake-session-secret",
   "cacheEnabled": true,
   "redisPort": "6379",
+  "fraudBlockEnabled": true,
   "redisHost": "127.0.0.1",
   "spIdpSsoBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
   "idpSamlLoginsEnabled": true,
   "logStyleElementsEnabled": true,
-  "idpSamlLogins": 
+  "idpSamlLogins":
   [
     {
       "category": "example2SamlIdp",

--- a/dev-config.base.json
+++ b/dev-config.base.json
@@ -29,7 +29,8 @@
   "spIdpSsoBinding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
   "idpSamlLoginsEnabled": true,
   "logStyleElementsEnabled": true,
-  "idpSamlLogins": 
+  "fraudBlockEnabled": true,
+  "idpSamlLogins":
   [
     {
       "category": "example2SamlIdp",

--- a/src/MpiUserClient.test.ts
+++ b/src/MpiUserClient.test.ts
@@ -50,6 +50,7 @@ beforeEach(() => {
             icn: "fakeICN",
             first_name: "Edward",
             last_name: "Paget",
+            id_theft_indicator: true,
           },
         },
       },
@@ -62,7 +63,8 @@ describe("getMVITraitsForLoa3User", () => {
     const client = new MpiUserClient(
       "faketoken",
       "https://example.gov/mvi-user",
-      "faketoken"
+      "faketoken",
+      true
     );
     await client.getMpiTraitsForLoa3User(samlTraitsEDIPI);
     expect(axios.post).toHaveBeenCalledWith(
@@ -89,7 +91,8 @@ describe("getMVITraitsForLoa3User", () => {
     const client = new MpiUserClient(
       "faketoken",
       "https://example.gov/mpi-user",
-      "faketoken"
+      "faketoken",
+      true
     );
     await client.getMpiTraitsForLoa3User(samlTraitsICN);
     expect(axios.post).toHaveBeenCalledWith(
@@ -111,7 +114,8 @@ describe("getMVITraitsForLoa3User", () => {
     const client = new MpiUserClient(
       "faketoken",
       "https://example.gov/mpi-user",
-      "faketoken"
+      "faketoken",
+      true
     );
     await client.getMpiTraitsForLoa3User(samlTraits);
     expect(axios.post).toHaveBeenCalledWith(
@@ -138,9 +142,11 @@ describe("getMVITraitsForLoa3User", () => {
     const client = new MpiUserClient(
       "faketoken",
       "https://example.gov",
-      "faketoken"
+      "faketoken",
+      false
     );
-    const { icn } = await client.getMpiTraitsForLoa3User(samlTraits);
-    expect(icn).toEqual("fakeICN");
+    const mpiTraits = await client.getMpiTraitsForLoa3User(samlTraits);
+    expect(mpiTraits.icn).toEqual("fakeICN");
+    expect(mpiTraits.idTheftIndicator).toEqual(false);
   });
 });

--- a/src/MpiUserClient.ts
+++ b/src/MpiUserClient.ts
@@ -4,20 +4,20 @@ import axios from "axios";
 export class MpiUserClient {
   mpiUserEndpoint: string;
   headers: object;
-  fraudIdTheft: boolean;
+  fraudBlockEnabled: boolean;
 
   constructor(
     apiKey: string,
     mpiUserEndpoint: string,
     accessKey: string,
-    fraudIdTheft: boolean
+    fraudBlockEnabled: boolean
   ) {
     this.mpiUserEndpoint = mpiUserEndpoint;
     this.headers = {
       apiKey: apiKey,
       accesskey: accessKey,
     };
-    this.fraudIdTheft = fraudIdTheft;
+    this.fraudBlockEnabled = fraudBlockEnabled;
   }
 
   public async getMpiTraitsForLoa3User(

--- a/src/MpiUserClient.ts
+++ b/src/MpiUserClient.ts
@@ -4,13 +4,20 @@ import axios from "axios";
 export class MpiUserClient {
   mpiUserEndpoint: string;
   headers: object;
+  fraudIdTheft: boolean;
 
-  constructor(apiKey: string, mpiUserEndpoint: string, accessKey: string) {
+  constructor(
+    apiKey: string,
+    mpiUserEndpoint: string,
+    accessKey: string,
+    fraudIdTheft: boolean
+  ) {
     this.mpiUserEndpoint = mpiUserEndpoint;
     this.headers = {
       apiKey: apiKey,
       accesskey: accessKey,
     };
+    this.fraudIdTheft = fraudIdTheft;
   }
 
   public async getMpiTraitsForLoa3User(

--- a/src/MpiUserClient.ts
+++ b/src/MpiUserClient.ts
@@ -15,7 +15,12 @@ export class MpiUserClient {
 
   public async getMpiTraitsForLoa3User(
     user: SAMLUser
-  ): Promise<{ icn: string; first_name: string; last_name: string }> {
+  ): Promise<{
+    icn: string;
+    first_name: string;
+    last_name: string;
+    idTheftIndicator: boolean;
+  }> {
     const body: Record<string, any> = {
       idp_uuid: user.uuid,
       dslogon_edipi: user.edipi || null,
@@ -38,7 +43,12 @@ export class MpiUserClient {
       })
       .then((response) => {
         const data = response.data.data;
-        return data.attributes;
+        return {
+          icn: data.attributes.icn,
+          first_name: data.attributes.first_name,
+          last_name: data.attributes.last_name,
+          idTheftIndicator: data.id_theft_indicator || false,
+        };
       })
       .catch(() => {
         throw {

--- a/src/MpiUserClientConfig.js
+++ b/src/MpiUserClientConfig.js
@@ -3,6 +3,6 @@ export default class MpiUserClientConfig {
     this.mpiUserEndpoint = argv.mpiUserEndpoint;
     this.accessKey = argv.accessKey;
     this.apiKey = argv.vetsAPIToken;
-    this.fraudIdTheft = argv.fraudBlockEnabled || false;
+    this.fraudBlockEnabled = argv.fraudBlockEnabled || false;
   }
 }

--- a/src/MpiUserClientConfig.js
+++ b/src/MpiUserClientConfig.js
@@ -3,5 +3,6 @@ export default class MpiUserClientConfig {
     this.mpiUserEndpoint = argv.mpiUserEndpoint;
     this.accessKey = argv.accessKey;
     this.apiKey = argv.vetsAPIToken;
+    this.fraudIdTheft = argv.fraudBlockEnabled || false;
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -102,7 +102,7 @@ function runServer(argv) {
         mpiUserClientConfig.apiKey,
         mpiUserClientConfig.mpiUserEndpoint,
         mpiUserClientConfig.accessKey,
-        mpiUserClientConfig.fraudIdTheft
+        mpiUserClientConfig.fraudBlockEnabled
       );
       const vsoClient = new VsoClient(
         vsoConfig.token,

--- a/src/app.js
+++ b/src/app.js
@@ -101,7 +101,8 @@ function runServer(argv) {
       const mpiUserClient = new MpiUserClient(
         mpiUserClientConfig.apiKey,
         mpiUserClientConfig.mpiUserEndpoint,
-        mpiUserClientConfig.accessKey
+        mpiUserClientConfig.accessKey,
+        mpiUserClientConfig.fraudIdTheft
       );
       const vsoClient = new VsoClient(
         vsoConfig.token,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -41,6 +41,13 @@ export function processArgs() {
           KEY_CERT_HELP_TEXT
         ),
       },
+      fraudBlockEnabled: {
+        description:
+          "Enable or disable blocking logins based on the fraud identity indicator",
+        required: false,
+        boolean: true,
+        default: true,
+      },
       idpKey: {
         description: "IdP Signature PrivateKey Certificate",
         required: true,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -46,7 +46,7 @@ export function processArgs() {
           "Enable or disable blocking logins based on the fraud identity indicator",
         required: false,
         boolean: true,
-        default: true,
+        default: false,
       },
       idpKey: {
         description: "IdP Signature PrivateKey Certificate",

--- a/src/routes/acsHandlers.test.ts
+++ b/src/routes/acsHandlers.test.ts
@@ -212,8 +212,6 @@ describe("scrubUserClaims", () => {
   });
 });
 
-
-
 describe("loadICN", () => {
   beforeEach(() => {
     // @ts-ignore
@@ -222,11 +220,11 @@ describe("loadICN", () => {
     vsoClient.getVSOSearch.mockReset();
   });
 
-  it("should block login when fraudIdTheft is true and idTheftIndicator is true", async () => {
+  it("should block login when fraudBlockEnabled is true and idTheftIndicator is true", async () => {
     const nextFn = jest.fn();
     const renderMock = jest.fn();
     const req: any = {
-      mpiUserClient: { ...mpiUserClient, fraudIdTheft: true },
+      mpiUserClient: { ...mpiUserClient, fraudBlockEnabled: true },
       vsoClient: vsoClient,
       user: {
         claims: { ...claimsWithICN },
@@ -250,11 +248,11 @@ describe("loadICN", () => {
     expect(nextFn).not.toHaveBeenCalled();
   });
 
-  it("should not block login when fraudIdTheft is true and idTheftIndicator is false", async () => {
+  it("should not block login when fraudBlockEnabled is true and idTheftIndicator is false", async () => {
     const nextFn = jest.fn();
     const renderMock = jest.fn();
     const req: any = {
-      mpiUserClient: { ...mpiUserClient, fraudIdTheft: true },
+      mpiUserClient: { ...mpiUserClient, fraudBlockEnabled: true },
       vsoClient: vsoClient,
       user: {
         claims: { ...claimsWithICN },
@@ -266,6 +264,32 @@ describe("loadICN", () => {
       first_name: "Edward",
       last_name: "Paget",
       idTheftIndicator: false,
+    });
+
+    const response: any = { render: renderMock };
+    await handlers.loadICN(req, response, nextFn);
+
+    expect(renderMock).not.toHaveBeenCalled();
+    expect(nextFn).toHaveBeenCalled();
+    expect(req.user.claims.icn).toEqual("anICN");
+  });
+
+  it("should not block login when fraudBlockEnabled is false and idTheftIndicator is true", async () => {
+    const nextFn = jest.fn();
+    const renderMock = jest.fn();
+    const req: any = {
+      mpiUserClient: { ...mpiUserClient, fraudBlockEnabled: false },
+      vsoClient: vsoClient,
+      user: {
+        claims: { ...claimsWithICN },
+      },
+    };
+
+    req.mpiUserClient.getMpiTraitsForLoa3User.mockResolvedValueOnce({
+      icn: "anICN",
+      first_name: "Edward",
+      last_name: "Paget",
+      idTheftIndicator: true,
     });
 
     const response: any = { render: renderMock };

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -22,8 +22,6 @@ import {
 } from "../metrics";
 import rTracer from "cls-rtracer";
 import { selectPassportStrategyKey } from "./passport";
-import { processArgs } from "../cli";
-const argv = processArgs();
 
 const unknownUsersErrorTemplate = (error: any) => {
   // `error` comes from:
@@ -143,9 +141,10 @@ export const loadICN = async (
       result: "success",
     });
 
-    if (argv.fraudBlockEnabled && idTheftIndicator) {
+    if (req.mpiUserClient.fraudIdTheft && idTheftIndicator) {
       logger.warn("Fradulent identity detected, blocking login.");
-      return res.render("sensitive_error", {
+      return res.render("layout", {
+        body: "sensitive_error",
         request_id: rTracer.id(),
       });
     }

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -141,7 +141,7 @@ export const loadICN = async (
       result: "success",
     });
 
-    if (req.mpiUserClient.fraudIdTheft && idTheftIndicator) {
+    if (req.mpiUserClient.fraudBlockEnabled && idTheftIndicator) {
       logger.warn("Fradulent identity detected, blocking login.");
       return res.render("layout", {
         body: "sensitive_error",

--- a/src/routes/acsHandlers.ts
+++ b/src/routes/acsHandlers.ts
@@ -22,6 +22,8 @@ import {
 } from "../metrics";
 import rTracer from "cls-rtracer";
 import { selectPassportStrategyKey } from "./passport";
+import { processArgs } from "../cli";
+const argv = processArgs();
 
 const unknownUsersErrorTemplate = (error: any) => {
   // `error` comes from:
@@ -123,7 +125,12 @@ export const loadICN = async (
   const action = "loadICN";
 
   try {
-    const { icn, first_name, last_name } = await requestWithMetrics(
+    const {
+      icn,
+      first_name,
+      last_name,
+      idTheftIndicator,
+    } = await requestWithMetrics(
       MVIRequestMetrics,
       (): Promise<any> => {
         return req.mpiUserClient.getMpiTraitsForLoa3User(req.user.claims);
@@ -135,6 +142,13 @@ export const loadICN = async (
       action,
       result: "success",
     });
+
+    if (argv.fraudBlockEnabled && idTheftIndicator) {
+      logger.warn("Fradulent identity detected, blocking login.");
+      return res.render("sensitive_error", {
+        request_id: rTracer.id(),
+      });
+    }
     req.user.claims.icn = icn;
     if (first_name) {
       req.user.claims.firstName = first_name;

--- a/test/testServer.js
+++ b/test/testServer.js
@@ -36,6 +36,7 @@ const defaultTestingConfig = {
   spValidateNameIDFormat: true,
   spNameIDFormat: "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
   spRequestAuthnContext: true,
+  fraudBlockEnabled: true,
 };
 
 export const idpConfig = new IDPConfig(defaultTestingConfig);


### PR DESCRIPTION
This PR is to add the fraud identity theft check in saml-proxy to block any login via the SAML Proxy that is identified to have a Fraud Identity Flag returned from MPI/ICN.

Link to Jira: https://jira.devops.va.gov/browse/API-41014